### PR TITLE
feat: finish neverthrow migration for auth utilities

### DIFF
--- a/packages/web/src/components/default-catch-boundary.tsx
+++ b/packages/web/src/components/default-catch-boundary.tsx
@@ -14,8 +14,6 @@ export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
     select: (state) => state.id === rootRouteId,
   });
 
-  console.error(error);
-
   return (
     <div className="min-w-0 flex-1 p-4 flex flex-col items-center justify-center gap-6">
       <ErrorComponent error={error} />

--- a/packages/web/src/lib/auth/server.ts
+++ b/packages/web/src/lib/auth/server.ts
@@ -6,31 +6,73 @@ import {
 } from "@tanstack/react-start/server";
 import { Tokens } from "./client";
 
+const TokensError = CustomError("Error Setting Tokens", "TokensError");
+
+export const Errors = {
+  Tokens: {
+    Get: new TokensError("An error occurred while getting the tokens."),
+    Write: new TokensError("An error occurred while setting the cookie."),
+    Delete: new TokensError("An error occurred while deleting the cookie."),
+    NotPresent: (t: string[]) =>
+      new TokensError(
+        `The provided tokens: [${t.join(", ")}] were not present.`
+      ),
+  },
+};
+
+import { Result } from "neverthrow";
+import { CustomError } from "../errors";
+
 export function TokenUtils() {
+  const safeGet = (key: string) =>
+    Result.fromThrowable(() => {
+      return getCookie(key);
+    })().mapErr(() => Errors.Tokens.NotPresent([key]));
+
+  const safeDelete = (key: string) =>
+    Result.fromThrowable(() => {
+      deleteCookie(key);
+    })().mapErr(() => Errors.Tokens.Delete);
+
+  // can't access the type for this function sadly
+  const safeSet = (
+    key: string,
+    value: string,
+    options: Parameters<typeof setCookie>[3]
+  ) => {
+    return Result.fromThrowable(() => {
+      setCookie(key, value, options);
+    })().mapErr(() => Errors.Tokens.Write);
+  };
+
   return {
     getFromCookies: () => {
-      return {
-        access: getCookie(keys.access),
-        refresh: getCookie(keys.refresh),
-      };
+      const access = safeGet(keys.access);
+      const refresh = safeGet(keys.refresh);
+
+      return Result.combine([access, refresh]).map(([access, refresh]) => ({
+        access,
+        refresh,
+      }));
     },
     deleteFromCookies: () => {
-      deleteCookie(keys.access);
-      deleteCookie(keys.refresh);
+      const access = safeDelete(keys.access);
+      const refresh = safeDelete(keys.refresh);
+
+      return Result.combine([access, refresh]).map(() => undefined);
     },
     setToCookies: (tokens: Tokens) => {
-      setCookie(keys.access, tokens.access, {
+      const options = {
         path: "/",
         httpOnly: true,
         sameSite: "lax",
         maxAge: 34560000,
-      });
-      setCookie(keys.refresh, tokens.refresh, {
-        path: "/",
-        httpOnly: true,
-        sameSite: "lax",
-        maxAge: 34560000,
-      });
+      } as const;
+
+      const access = safeSet(keys.access, tokens.access, options);
+      const refresh = safeSet(keys.refresh, tokens.refresh, options);
+
+      return Result.combine([access, refresh]).map(() => undefined);
     },
   };
 }

--- a/packages/web/src/lib/zero/react.tsx
+++ b/packages/web/src/lib/zero/react.tsx
@@ -26,7 +26,8 @@ export const ZeroProvider = (props: PropsWithChildren) => {
       function success(z) {
         setZero(z);
       },
-      function error() {
+      function error(e) {
+        console.error("error", e);
         setZero(CAN_NOT_INSTANTIATE_ZERO);
       }
     );


### PR DESCRIPTION
converges to a standard pattern for handling success/error paths with neverthrow
- mainly converts TokenUtils to using this pattern in all methods
- abstracts `authenticate` logic to be reused internally and in RPC's

todo:
still need to converge on a much more conventional error pattern. there's currently a huge mess of nonsensical custom errors littered everywhere