### PR TITLE
refactor: core package neverthrow -> effect

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,8 +31,10 @@
     "drizzle-orm": "^0.39.0",
     "drizzle-seed": "^0.3.1",
     "drizzle-valibot": "^0.4.1",
+    "effect": "^3.13.10",
     "neverthrow": "^8.2.0",
     "postgres": "^3.4.5",
-    "valibot": "^1.0.0"
+    "valibot": "^1.0.0",
+    "ws": "^8.18.2"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,7 @@
     "ai": "^4.3.4",
     "autoevals": "^0.0.127",
     "braintrust": "^0.0.197",
-    "drizzle-orm": "^0.39.0",
+    "drizzle-orm": "^0.39.3",
     "drizzle-seed": "^0.3.1",
     "drizzle-valibot": "^0.4.1",
     "effect": "^3.13.10",
@@ -36,5 +36,8 @@
     "postgres": "^3.4.5",
     "valibot": "^1.0.0",
     "ws": "^8.18.2"
+  },
+  "devDependencies": {
+    "@types/ws": "^8.18.1"
   }
 }

--- a/packages/core/src/db/+schema.register.ts
+++ b/packages/core/src/db/+schema.register.ts
@@ -1,0 +1,6 @@
+export * from "./expense.schema";
+export * from "./group.schema";
+export * from "./member.schema";
+export * from "./participant.schema";
+export * from "./preference.schema";
+export * from "./user.schema";

--- a/packages/core/src/db/expense.ts
+++ b/packages/core/src/db/expense.ts
@@ -38,7 +38,7 @@ function findClosestName(name: string, names: string[]) {
     onTrue: () => Effect.succeed(bestMatch),
     onFalse: () =>
       Effect.fail(
-        new NoMemberMatchFound("Member from parse not found in group")
+        new NoMemberMatchFound("Member from parse not found in group"),
       ),
   });
 }
@@ -66,18 +66,18 @@ export namespace expenses {
         (tx ?? db)
           .insert(expenseTable)
           .values(expense)
-          .returning({ id: expenseTable.id })
+          .returning({ id: expenseTable.id }),
       ),
       Effect.flatMap(
         requireSingleElement({
           empty: () => new ExpenseNotCreatedError("Expense not created"),
           dup: () => new DuplicateExpenseError("Duplicate expense found"),
-        })
+        }),
       ),
       Effect.catchTag(
         "UnknownException",
-        (e) => new DatabaseWriteError("Failed creating expense", e)
-      )
+        (e) => new DatabaseWriteError("Failed creating expense", e),
+      ),
     );
   }
 
@@ -101,7 +101,7 @@ export namespace expenses {
 
       if (!user) {
         return yield* Effect.fail(
-          new UserMissingInParse("User omitted from parse")
+          new UserMissingInParse("User omitted from parse"),
         );
       }
 
@@ -109,7 +109,7 @@ export namespace expenses {
 
       const restMapped = yield* normalize(
         generated.members.filter((m) => m.name !== USER),
-        members
+        members,
       );
 
       const merged = [userMapped, ...restMapped];
@@ -126,7 +126,7 @@ export namespace expenses {
           groupId: options.groupId,
           expenseId: newExpense.id,
           ...m,
-        }))
+        })),
       );
 
       return {
@@ -142,7 +142,7 @@ export namespace expenses {
           case "DatabaseWriteError":
           case "ExpenseNotCreatedError":
           case "ParticipantsNotCreatedError":
-            return new ExpenseNotCreatedError("Failed parsing expense", error);
+            return new ExpenseNotCreatedError("Failed creating expense", error);
           case "UserMissingInParse":
           case "NoMemberMatchFound":
           case "ExpenseParsingError":

--- a/packages/core/src/db/group.ts
+++ b/packages/core/src/db/group.ts
@@ -1,7 +1,7 @@
 import { eq } from "drizzle-orm";
 import { db } from ".";
 import { groupTable } from "./group.schema";
-import { DatabaseReadError, Transaction } from "./utils";
+import { DatabaseReadError } from "./utils";
 import { Effect, pipe } from "effect";
 import { requireValueExists, requireManyElements, TaggedError } from "../utils";
 
@@ -9,13 +9,12 @@ class GroupNotFoundError extends TaggedError("GroupNotFoundError") {}
 class MembersNotFoundError extends TaggedError("MembersNotFoundError") {}
 
 export namespace groups {
-  export function getMembers(groupId: string, tx?: Transaction) {
+  export function getMembers(groupId: string) {
     return pipe(
       Effect.tryPromise(() =>
-        (tx ?? db).query.groupTable.findFirst({
+        db.query.groupTable.findFirst({
           where: eq(groupTable.id, groupId),
           with: { members: true },
-          columns: {}, // TODO: check to keep/remove
         })
       ),
       Effect.flatMap(

--- a/packages/core/src/db/group.ts
+++ b/packages/core/src/db/group.ts
@@ -1,29 +1,39 @@
 import { eq } from "drizzle-orm";
-import { db, Member } from ".";
+import { db } from ".";
 import { groupTable } from "./group.schema";
-import { DrizzleResult, fromDrizzleThrowable } from "./utils";
-import { err, ok } from "neverthrow";
+import { DatabaseReadError, Transaction } from "./utils";
+import { Effect, pipe } from "effect";
+import { requireValueExists, requireManyElements, TaggedError } from "../utils";
 
-const Errors = {
-  NoMembersFound: () => new Error("No members found"),
-};
+class GroupNotFoundError extends TaggedError("GroupNotFoundError") {}
+class MembersNotFoundError extends TaggedError("MembersNotFoundError") {}
 
 export namespace groups {
-  export function getMembers(groupId: string): DrizzleResult<Member[]> {
-    const safelyInsertgroupRecord = fromDrizzleThrowable(() =>
-      db.query.groupTable.findFirst({
-        where: eq(groupTable.id, groupId),
-        with: {
-          members: true,
-        },
-        columns: {},
-      })
+  export function getMembers(groupId: string, tx?: Transaction) {
+    return pipe(
+      Effect.tryPromise(() =>
+        (tx ?? db).query.groupTable.findFirst({
+          where: eq(groupTable.id, groupId),
+          with: { members: true },
+          columns: {}, // TODO: check to keep/remove
+        })
+      ),
+      Effect.flatMap(
+        requireValueExists({
+          success: (group) => group.members,
+          error: () => new GroupNotFoundError("Group not found"),
+        })
+      ),
+      Effect.flatMap(
+        requireManyElements({
+          success: (members) => members,
+          empty: () => new MembersNotFoundError("Members not found"),
+        })
+      ),
+      Effect.catchTag(
+        "UnknownException",
+        (e) => new DatabaseReadError("Failed fetching members by group id", e)
+      )
     );
-
-    return safelyInsertgroupRecord().andThen((group) => {
-      return !group || group.members.length === 0
-        ? err(Errors.NoMembersFound())
-        : ok(group.members);
-    });
   }
 }

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -5,9 +5,9 @@ import * as participant from "./participant.schema";
 import * as preference from "./preference.schema";
 import * as user from "./user.schema";
 
-import { neon } from "@neondatabase/serverless";
-import { drizzle } from "drizzle-orm/neon-http";
+import { drizzle } from "drizzle-orm/neon-serverless";
 import { Resource } from "sst";
+import ws from "ws";
 
 export * from "./expense.schema";
 export * from "./expense";
@@ -19,6 +19,7 @@ export * from "./participant";
 export * from "./preference.schema";
 export * from "./user.schema";
 export * from "./users";
+export * from "./utils";
 
 const {
   host: dbHost,
@@ -36,7 +37,8 @@ export const schemas = {
   ...participant,
 };
 
-export const db = drizzle(
-  neon(`postgresql://${dbUser}:${dbPassword}@${dbHost}/${dbDatabase}`),
-  { schema: schemas }
-);
+export const db = drizzle({
+  connection: `postgresql://${dbUser}:${dbPassword}@${dbHost}/${dbDatabase}`,
+  ws: ws,
+  schema: schemas,
+});

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -1,23 +1,13 @@
-import * as expense from "./expense.schema";
-import * as group from "./group.schema";
-import * as member from "./member.schema";
-import * as participant from "./participant.schema";
-import * as preference from "./preference.schema";
-import * as user from "./user.schema";
-
 import { drizzle } from "drizzle-orm/neon-serverless";
 import { Resource } from "sst";
 import ws from "ws";
 
-export * from "./expense.schema";
+import * as schemas from "./+schema.register";
+
+export * from "./+schema.register";
 export * from "./expense";
-export * from "./group.schema";
 export * from "./group";
-export * from "./member.schema";
-export * from "./participant.schema";
 export * from "./participant";
-export * from "./preference.schema";
-export * from "./user.schema";
 export * from "./users";
 export * from "./utils";
 
@@ -27,15 +17,6 @@ const {
   password: dbPassword,
   database: dbDatabase,
 } = Resource.Database;
-
-export const schemas = {
-  ...user,
-  ...group,
-  ...member,
-  ...preference,
-  ...expense,
-  ...participant,
-};
 
 export const db = drizzle({
   connection: `postgresql://${dbUser}:${dbPassword}@${dbHost}/${dbDatabase}`,

--- a/packages/core/src/db/users.ts
+++ b/packages/core/src/db/users.ts
@@ -16,12 +16,11 @@ class DuplicateUserError extends TaggedError("DuplicateUserError") {}
 
 export namespace users {
   export function getByEmail(
-    email: string,
-    tx?: Transaction
+    email: string
   ): Effect.Effect<string, UserNotFoundError | DatabaseReadError> {
     return pipe(
       Effect.tryPromise(() =>
-        (tx ?? db).query.userTable.findFirst({
+        db.query.userTable.findFirst({
           where: eq(userTable.email, email),
         })
       ),
@@ -39,12 +38,11 @@ export namespace users {
   }
 
   export function getById(
-    id: string,
-    tx?: Transaction
+    id: string
   ): Effect.Effect<User, UserNotFoundError | DatabaseReadError> {
     return pipe(
       Effect.tryPromise(() =>
-        (tx ?? db).query.userTable.findFirst({ where: eq(userTable.id, id) })
+        db.query.userTable.findFirst({ where: eq(userTable.id, id) })
       ),
       Effect.flatMap(
         requireValueExists({

--- a/packages/core/src/db/utils.ts
+++ b/packages/core/src/db/utils.ts
@@ -5,6 +5,11 @@ import {
 } from "drizzle-orm";
 import { PgTable, text } from "drizzle-orm/pg-core";
 import { ResultAsync } from "neverthrow";
+import { db } from ".";
+import { TaggedError } from "../utils";
+
+export class DatabaseReadError extends TaggedError("DatabaseReadError") {}
+export class DatabaseWriteError extends TaggedError("DatabaseWriteError") {}
 
 export type DrizzleResult<T, R = DrizzleError> = ResultAsync<T, R>;
 
@@ -35,3 +40,7 @@ export type DrizzleModelTypes<Model extends PgTable> = {
 
 export const clean = (input: string[]) =>
   input.map((item) => item.trim()).filter((item) => item);
+
+export type Transaction = Parameters<
+  Parameters<(typeof db)["transaction"]>[0]
+>[0];

--- a/packages/core/src/utils/effect.ts
+++ b/packages/core/src/utils/effect.ts
@@ -1,0 +1,104 @@
+import { Data, Match, Effect } from "effect";
+
+/**
+ * Creates a tagged error class with a specific name and error structure.
+ * @template T - The string literal type for the error name
+ * @param name - The name of the error class
+ * @returns A class that extends Data.TaggedError with the specified name
+ */
+export function TaggedError<T extends string>(name: T) {
+  type E = {
+    message: string;
+    cause?: unknown;
+  };
+
+  return class extends Data.TaggedError(name)<E> {
+    constructor(message: string, cause?: unknown) {
+      super({ message, cause });
+    }
+  };
+}
+
+/**
+ * Requires exactly one element in an array and handles success/empty/duplicate cases.
+ * @template TElement - The type of elements in the array
+ * @template TEmptyError - The error type returned when no elements are found
+ * @template TSuccess - The success type (defaults to TElement)
+ * @param context - Configuration object for handling different cases
+ * @param context.success - Optional function to transform the single element
+ * @param context.empty - Function to create error when no elements found
+ * @param context.dup - Function to create error when multiple elements found
+ * @returns A function that processes an array and returns an Effect, dies if multiple elements found
+ */
+export function requireSingleElement<
+  TElement,
+  TEmptyError,
+  TSuccess = TElement,
+>(context: {
+  success?: (row: TElement) => TSuccess;
+  empty: () => TEmptyError;
+  dup: () => unknown;
+}) {
+  return (rows: TElement[]) =>
+    Match.value(rows.length).pipe(
+      Match.when(1, () =>
+        context.success
+          ? Effect.succeed(context.success(rows[0]))
+          : Effect.succeed(rows[0] as unknown as TSuccess)
+      ),
+      Match.when(0, () => Effect.fail(context.empty())),
+      Match.orElse(() => Effect.die(context.dup()))
+    );
+}
+
+/**
+ * Requires at least one element in an array and handles success/empty cases.
+ * @template TElement - The type of elements in the array
+ * @template TSuccess - The success type (defaults to TElement[])
+ * @template TEmptyError - The error type returned when no elements are found
+ * @param context - Configuration object for handling different cases
+ * @param context.success - Optional function to transform the array of elements
+ * @param context.empty - Function to create error when no elements found
+ * @returns A function that processes an array and returns an Effect
+ */
+export function requireManyElements<
+  TElement,
+  TSuccess = TElement[],
+  TEmptyError = unknown,
+>(context: {
+  success?: (rows: TElement[]) => TSuccess;
+  empty: () => TEmptyError;
+}) {
+  return (rows: TElement[]) =>
+    Match.value(rows.length).pipe(
+      Match.when(0, () => Effect.fail(context.empty())),
+      Match.orElse(() =>
+        context.success
+          ? Effect.succeed(context.success(rows))
+          : Effect.succeed(rows as TSuccess)
+      )
+    );
+}
+
+/**
+ * Requires a value to exist (not null or undefined) and handles success/error cases.
+ * @template TValue - The type of the value to check
+ * @template TError - The error type returned when value doesn't exist
+ * @template TSuccess - The success type (defaults to TValue)
+ * @param context - Configuration object for handling different cases
+ * @param context.success - Optional function to transform the value
+ * @param context.error - Function to create error when value doesn't exist
+ * @returns A function that processes a value and returns an Effect
+ */
+export function requireValueExists<TValue, TError, TSuccess = TValue>(context: {
+  success?: (value: TValue) => TSuccess;
+  error: () => TError;
+}) {
+  return (value: TValue | null | undefined) => {
+    if (!value) return Effect.fail(context.error());
+
+    return context.success
+      ? Effect.succeed(context.success(value as TValue))
+      : Effect.succeed(value as TSuccess);
+  };
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -34,3 +34,4 @@ export function omitKey<T extends object, K extends keyof T>(
 }
 
 export * from "./neverthrow";
+export * from "./effect";

--- a/packages/core/src/utils/string-similarity.ts
+++ b/packages/core/src/utils/string-similarity.ts
@@ -1,3 +1,5 @@
+export const MIN_MATCH_THRESHOLD = 0.5;
+
 /**
  * Calculates the Levenshtein distance between two strings
  * @param a First string

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -4,6 +4,8 @@
     "strict": true,
     "strictNullChecks": true,
     "module": "ESNext",
-    "moduleResolution": "Bundler"
+    "moduleResolution": "Bundler",
+    "lib": ["ESNext"],
+    "target": "ESNext"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -39,6 +39,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "effect": "^3.13.10",
     "jose": "^6.0.10",
     "js-cookie": "^3.0.5",
     "lucide-react": "^0.476.0",
@@ -53,7 +54,8 @@
     "tailwindcss": "^4.0.8",
     "tailwindcss-animate": "^1.0.7",
     "valibot": "^1.0.0",
-    "vinxi": "0.5.3"
+    "vinxi": "0.5.3",
+    "ws": "^8.18.2"
   },
   "devDependencies": {
     "@types/js-cookie": "^3.0.6"

--- a/packages/web/src/lib/auth.provider.tsx
+++ b/packages/web/src/lib/auth.provider.tsx
@@ -1,5 +1,4 @@
 import { type ReactNode } from "react";
-import { hydrateAsyncServerResult, unwrapOrThrow } from "@blank/core/utils";
 import { Navigate } from "@tanstack/react-router";
 import { Loading } from "@/components/loading";
 import { logoutRPC, meRPC } from "@/server/auth/route";
@@ -23,7 +22,8 @@ export function authenticationQueryOptions() {
   return queryOptions({
     queryKey: ["authentication"],
     queryFn: async () => {
-      return unwrapOrThrow(hydrateAsyncServerResult(meRPC));
+      console.log("queryFn running");
+      return meRPC();
     },
   });
 }
@@ -49,8 +49,5 @@ export function useAuthentication() {
     throw new Error("useAuth must be used beneath the AuthProvider");
   }
 
-  return {
-    user: query.data[0],
-    token: query.data[1],
-  };
+  return query.data;
 }

--- a/packages/web/src/server/auth/route.ts
+++ b/packages/web/src/server/auth/route.ts
@@ -1,68 +1,107 @@
-import { getHeader } from "@tanstack/react-start/server";
-import { subjects } from "@blank/auth/subjects";
-import { redirect } from "@tanstack/react-router";
+// import { getHeader } from "@tanstack/react-start/server";
+// import { subjects } from "@blank/auth/subjects";
+// import { redirect } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
-import { err, ok, Result } from "neverthrow";
 import { users } from "@blank/core/db";
-import { serverResult } from "@blank/core/utils";
-import { authenticate, openauth } from "@/server/auth/core";
+// import { requireValueExists, TaggedError } from "@blank/core/utils";
+import { authenticate } from "@/server/auth/core";
 import { AuthTokens } from "@/server/utils";
-import { evaluate } from "@/lib/utils";
+import { Effect, pipe } from "effect";
 
-const assertPresent =
-  (message: string) =>
-  <T>(value: T | null | undefined) =>
-    value ? ok(value) : err(message);
+// class AuthenticatedError extends TaggedError("AuthenticatedError") {}
 
 export const authenticateRPC = createServerFn().handler(async function () {
   return authenticate({ cookies: AuthTokens.cookies });
 });
 
 export const meRPC = createServerFn().handler(async function () {
-  const auth = await authenticate({ cookies: AuthTokens.cookies });
-
-  const subject = ok(auth)
-    .andThen(assertPresent("Could not subject from auth server"))
-    .map((result) => result.subject.properties);
-
-  const user = await subject
-    .asyncAndThen((subject) => users.getAuthenticatedUser(subject.userID))
-    .andThen(assertPresent("Could not fetch current user"));
-
-  const access = ok(AuthTokens.cookies.get().access).andThen(
-    assertPresent("Could not find access token")
+  const authenticated = Effect.tryPromise(() =>
+    authenticate({ cookies: AuthTokens.cookies })
   );
 
-  return serverResult(Result.combine([user, access]));
+  const user = pipe(
+    authenticated,
+    // Effect.flatMap(
+    //   requireValueExists({
+    //     error: () => new AuthenticatedError("Could not authenticate user"),
+    //   })
+    // ),
+    Effect.map((result) => result?.subject.properties.userID ?? ""),
+    Effect.flatMap(users.getById)
+    // Effect.flatMap(
+    //   requireValueExists({
+    //     error: () => new AuthenticatedError("Could not fetch current user"),
+    //   })
+    // )
+  );
+
+  const token = pipe(
+    Effect.try(() => AuthTokens.cookies.get()),
+    Effect.map((tokens) => tokens.access)
+    // Effect.flatMap(
+    //   requireValueExists({
+    //     error: () => new AuthenticatedError("Could not fetch access token"),
+    //   })
+    // )
+  );
+
+  const result = pipe(
+    Effect.all([user, token]),
+    Effect.map(([user, token]) => ({ user, token })),
+    Effect.runPromise
+  );
+
+  return result;
 });
 
-export const loginRPC = createServerFn().handler(async function () {
-  const { access, refresh } = AuthTokens.cookies.get();
+// export const meRPCTwo = createServerFn().handler(async function () {
+//   const auth = await authenticate({ cookies: AuthTokens.cookies });
 
-  if (access) {
-    const verified = await openauth.verify(subjects, access, { refresh });
+//   const subject = ok(auth)
+//     .andThen(assertPresent("Could not subject from auth server"))
+//     .map((result) => result.subject.properties);
 
-    if (!verified.err && verified.tokens) {
-      AuthTokens.cookies.set(verified.tokens);
-      throw redirect({ to: "/" });
-    }
-  }
+//   const user = await subject
+//     .asyncAndThen((subject) => {
+//       const promise = Effect.runPromise(users.getById(subject.userID)); // interoping with effect for now
+//       return ResultAsync.fromPromise(promise, (e) => e);
+//     })
+//     .andThen(assertPresent("Could not fetch current user"));
 
-  const uri = evaluate(() => {
-    const host = getHeader("host");
-    const protocol = host?.includes("localhost") ? "http" : "https";
+//   const access = ok(AuthTokens.cookies.get().access).andThen(
+//     assertPresent("Could not find access token")
+//   );
 
-    return host ? `${protocol}://${host}/api/auth/callback` : null;
-  });
+//   return serverResult(Result.combine([user, access]));
+// });
 
-  if (!uri) throw new Error("Failed to get callback URL"); // should be a result eventually
+// export const loginRPC = createServerFn().handler(async function () {
+//   const { access, refresh } = AuthTokens.cookies.get();
 
-  const { url } = await openauth.authorize(uri, "code");
+//   if (access) {
+//     const verified = await openauth.verify(subjects, access, { refresh });
 
-  throw redirect({ href: url });
-});
+//     if (!verified.err && verified.tokens) {
+//       AuthTokens.cookies.set(verified.tokens);
+//       throw redirect({ to: "/" });
+//     }
+//   }
 
-export const logoutRPC = createServerFn().handler(function () {
-  AuthTokens.cookies.delete();
-  throw redirect({ to: "/landing" });
-});
+//   const uri = evaluate(() => {
+//     const host = getHeader("host");
+//     const protocol = host?.includes("localhost") ? "http" : "https";
+
+//     return host ? `${protocol}://${host}/api/auth/callback` : null;
+//   });
+
+//   if (!uri) throw new Error("Failed to get callback URL"); // should be a result eventually
+
+//   const { url } = await openauth.authorize(uri, "code");
+
+//   throw redirect({ href: url });
+// });
+
+// export const logoutRPC = createServerFn().handler(function () {
+//   AuthTokens.cookies.delete();
+//   throw redirect({ to: "/landing" });
+// });

--- a/packages/web/src/server/auth/route.ts
+++ b/packages/web/src/server/auth/route.ts
@@ -1,14 +1,15 @@
-// import { getHeader } from "@tanstack/react-start/server";
-// import { subjects } from "@blank/auth/subjects";
-// import { redirect } from "@tanstack/react-router";
+import { getHeader } from "@tanstack/react-start/server";
+import { subjects } from "@blank/auth/subjects";
+import { redirect } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
 import { users } from "@blank/core/db";
-// import { requireValueExists, TaggedError } from "@blank/core/utils";
-import { authenticate } from "@/server/auth/core";
+import { requireValueExists, TaggedError } from "@blank/core/utils";
+import { authenticate, openauth } from "@/server/auth/core";
 import { AuthTokens } from "@/server/utils";
 import { Effect, pipe } from "effect";
+import { evaluate } from "@/lib/utils";
 
-// class AuthenticatedError extends TaggedError("AuthenticatedError") {}
+class AuthenticatedError extends TaggedError("AuthenticatedError") {}
 
 export const authenticateRPC = createServerFn().handler(async function () {
   return authenticate({ cookies: AuthTokens.cookies });
@@ -21,87 +22,65 @@ export const meRPC = createServerFn().handler(async function () {
 
   const user = pipe(
     authenticated,
-    // Effect.flatMap(
-    //   requireValueExists({
-    //     error: () => new AuthenticatedError("Could not authenticate user"),
-    //   })
-    // ),
-    Effect.map((result) => result?.subject.properties.userID ?? ""),
-    Effect.flatMap(users.getById)
-    // Effect.flatMap(
-    //   requireValueExists({
-    //     error: () => new AuthenticatedError("Could not fetch current user"),
-    //   })
-    // )
+    Effect.flatMap(
+      requireValueExists({
+        error: () => new AuthenticatedError("Could not authenticate user"),
+      })
+    ),
+    Effect.map((result) => result.subject.properties.userID),
+    Effect.flatMap(users.getById),
+    Effect.flatMap(
+      requireValueExists({
+        error: () => new AuthenticatedError("Could not fetch current user"),
+      })
+    )
   );
 
   const token = pipe(
     Effect.try(() => AuthTokens.cookies.get()),
-    Effect.map((tokens) => tokens.access)
-    // Effect.flatMap(
-    //   requireValueExists({
-    //     error: () => new AuthenticatedError("Could not fetch access token"),
-    //   })
-    // )
+    Effect.map((tokens) => tokens.access),
+    Effect.flatMap(
+      requireValueExists({
+        error: () => new AuthenticatedError("Could not fetch access token"),
+      })
+    )
   );
 
   const result = pipe(
     Effect.all([user, token]),
-    Effect.map(([user, token]) => ({ user, token })),
-    Effect.runPromise
+    Effect.map(([user, token]) => ({ user, token }))
   );
 
-  return result;
+  return Effect.runPromise(result);
 });
 
-// export const meRPCTwo = createServerFn().handler(async function () {
-//   const auth = await authenticate({ cookies: AuthTokens.cookies });
+export const loginRPC = createServerFn().handler(async function () {
+  const { access, refresh } = AuthTokens.cookies.get();
 
-//   const subject = ok(auth)
-//     .andThen(assertPresent("Could not subject from auth server"))
-//     .map((result) => result.subject.properties);
+  if (access) {
+    const verified = await openauth.verify(subjects, access, { refresh });
 
-//   const user = await subject
-//     .asyncAndThen((subject) => {
-//       const promise = Effect.runPromise(users.getById(subject.userID)); // interoping with effect for now
-//       return ResultAsync.fromPromise(promise, (e) => e);
-//     })
-//     .andThen(assertPresent("Could not fetch current user"));
+    if (!verified.err && verified.tokens) {
+      AuthTokens.cookies.set(verified.tokens);
+      throw redirect({ to: "/" });
+    }
+  }
 
-//   const access = ok(AuthTokens.cookies.get().access).andThen(
-//     assertPresent("Could not find access token")
-//   );
+  const uri = evaluate(() => {
+    const host = getHeader("host");
+    const protocol = host?.includes("localhost") ? "http" : "https";
 
-//   return serverResult(Result.combine([user, access]));
-// });
+    return host ? `${protocol}://${host}/api/auth/callback` : null;
+  });
 
-// export const loginRPC = createServerFn().handler(async function () {
-//   const { access, refresh } = AuthTokens.cookies.get();
+  if (!uri) throw new Error("Failed to get callback URL"); // should be a result eventually
 
-//   if (access) {
-//     const verified = await openauth.verify(subjects, access, { refresh });
+  const { url } = await openauth.authorize(uri, "code");
 
-//     if (!verified.err && verified.tokens) {
-//       AuthTokens.cookies.set(verified.tokens);
-//       throw redirect({ to: "/" });
-//     }
-//   }
+  throw redirect({ href: url });
+});
 
-//   const uri = evaluate(() => {
-//     const host = getHeader("host");
-//     const protocol = host?.includes("localhost") ? "http" : "https";
-
-//     return host ? `${protocol}://${host}/api/auth/callback` : null;
-//   });
-
-//   if (!uri) throw new Error("Failed to get callback URL"); // should be a result eventually
-
-//   const { url } = await openauth.authorize(uri, "code");
-
-//   throw redirect({ href: url });
-// });
-
-// export const logoutRPC = createServerFn().handler(function () {
-//   AuthTokens.cookies.delete();
-//   throw redirect({ to: "/landing" });
-// });
+export const logoutRPC = createServerFn().handler(function () {
+  AuthTokens.cookies.delete();
+  throw redirect({ to: "/landing" });
+});

--- a/packages/web/src/server/expense.route.ts
+++ b/packages/web/src/server/expense.route.ts
@@ -1,10 +1,14 @@
 import { createServerFn } from "@tanstack/react-start";
+import { requireValueExists, TaggedError } from "@blank/core/utils";
 import { expenses } from "@blank/core/db";
-import { serverResult } from "@blank/core/utils";
 import { authenticate } from "@/server/auth/core";
 import * as v from "valibot";
-import { err, ok } from "neverthrow";
 import { AuthTokens } from "@/server/utils";
+import { Effect, pipe } from "effect";
+
+class UserNotAuthenticatedError extends TaggedError(
+  "UserNotAuthenticatedError"
+) {}
 
 const inputs = {
   createFromDescription: v.object({
@@ -16,24 +20,21 @@ const inputs = {
 export const createFromDescriptionServerFn = createServerFn()
   .validator(inputs.createFromDescription)
   .handler(async function (ctx) {
-    const subject = ok(
-      await authenticate({ cookies: AuthTokens.cookies })
-    ).andThen((result) => {
-      return !!result
-        ? ok(result.subject.properties)
-        : err("Could not find user"); // [error] add tagged error
-    });
-
-    const result = await subject
-      .asyncAndThen((subject) =>
+    const result = pipe(
+      Effect.tryPromise(() => authenticate({ cookies: AuthTokens.cookies })),
+      Effect.flatMap(
+        requireValueExists({
+          error: () => new UserNotAuthenticatedError("User not authenticated"),
+        })
+      ),
+      Effect.flatMap((result) =>
         expenses.createFromDescription({
-          userId: subject.userID,
+          userId: result.subject.properties.userID,
           groupId: ctx.data.groupId,
           description: ctx.data.description,
         })
       )
-      .map((value) => value)
-      .mapErr((e) => e);
+    );
 
-    return serverResult(result);
+    return Effect.runPromise(result);
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,7 +139,7 @@ importers:
         specifier: ^0.0.197
         version: 0.0.197(openai@4.95.1(ws@8.18.2)(zod@3.24.2))(react@19.0.0)(solid-js@1.9.5)(sswr@2.2.0(svelte@5.26.2))(svelte@5.26.2)(vue@3.5.13(typescript@5.8.3))(zod@3.24.2)
       drizzle-orm:
-        specifier: ^0.39.0
+        specifier: ^0.39.3
         version: 0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)
       drizzle-seed:
         specifier: ^0.3.1
@@ -162,6 +162,10 @@ importers:
       ws:
         specifier: ^8.18.2
         version: 8.18.2
+    devDependencies:
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
 
   packages/server/api: {}
 
@@ -507,8 +511,16 @@ packages:
     resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.25.9':
     resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.27.1':
+    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.25.9':
@@ -521,6 +533,11 @@ packages:
 
   '@babel/parser@7.27.0':
     resolution: {integrity: sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.27.2':
+    resolution: {integrity: sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -558,6 +575,10 @@ packages:
 
   '@babel/types@7.27.0':
     resolution: {integrity: sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.27.1':
+    resolution: {integrity: sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==}
     engines: {node: '>=6.9.0'}
 
   '@badrap/valita@0.3.11':
@@ -3343,6 +3364,9 @@ packages:
   '@types/ws@8.18.0':
     resolution: {integrity: sha512-8svvI3hMyvN0kKCJMvTJP/x6Y/EoQbepff882wL+Sn5QsXb3etnamgrJq4isrBxSJj5L2AuXcI0+bgkoAXGUJw==}
 
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@typescript-eslint/eslint-plugin@8.31.0':
     resolution: {integrity: sha512-evaQJZ/J/S4wisevDvC1KFZkPzRetH8kYZbkgcTRyql3mcKsf+ZFDV1BVWUGTCAW5pQHoqn5gK5b8kn7ou9aFQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -5840,11 +5864,11 @@ packages:
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
 
-  pg-cloudflare@1.2.0:
-    resolution: {integrity: sha512-dhfTv9ZhBLHHjFjh1qeA/0xbaF9ax9fVp+jFCWEDR3Qtdj6oM+GybEewsvAjDkH1mu6dpiH2MSKSHmVDrZqrGA==}
+  pg-cloudflare@1.2.5:
+    resolution: {integrity: sha512-OOX22Vt0vOSRrdoUPKJ8Wi2OpE/o/h9T8X1s4qSkCedbNah9ei2W2765be8iMVxQUsvgT7zIAT2eIa9fs5+vtg==}
 
-  pg-connection-string@2.8.1:
-    resolution: {integrity: sha512-/K3E7SgRJms0N/GCEI5IsrfY86FzTAfox/5nRfJT0I1NGM0JPutpbKfVOSRnlMkIJYFmlyQ7+5jHEfL9IIPFLQ==}
+  pg-connection-string@2.9.0:
+    resolution: {integrity: sha512-P2DEBKuvh5RClafLngkAuGe9OUlFV7ebu8w1kmaaOgPcpJd1RIFh7otETfI6hAR8YupOLFTY7nuvvIn7PLciUQ==}
 
   pg-format-fix@1.0.5:
     resolution: {integrity: sha512-HcXVy9Zk4kn87P0+U9XSxGtenNyknbPB87NreixSBk0lYJy89u+d/zQbS+f/aTTxABQ/B6FH1KdBB5EsGzRS2w==}
@@ -5858,16 +5882,16 @@ packages:
     resolution: {integrity: sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==}
     engines: {node: '>=4'}
 
-  pg-pool@3.9.1:
-    resolution: {integrity: sha512-gC8F55MsCWsFmiXlNVzoyYU5tvhDrKqnpKG+YJzxjGwbOQxFHy/AS/QxuG8723OrxC6kTHxIrbAeelVAePqJyw==}
+  pg-pool@3.10.0:
+    resolution: {integrity: sha512-DzZ26On4sQ0KmqnO34muPcmKbhrjmyiO4lCCR0VwEd7MjmiKf5NTg/6+apUEu0NF7ESa37CGzFxH513CoUmWnA==}
     peerDependencies:
       pg: '>=8.0'
 
+  pg-protocol@1.10.0:
+    resolution: {integrity: sha512-IpdytjudNuLv8nhlHs/UrVBhU0e78J0oIS/0AVdTbWxSOkFUVdsHC/NrorO6nXsQNDTT1kzDSOMJubBQviX18Q==}
+
   pg-protocol@1.8.0:
     resolution: {integrity: sha512-jvuYlEkL03NRvOoyoRktBK7+qU5kOvlAwvmrH8sr3wbLrOdVWsRxQfz8mMy9sZFsqJ1hEWNfdWKI4SAmoL+j7g==}
-
-  pg-protocol@1.9.0:
-    resolution: {integrity: sha512-6AkqYKbOwHVlDnXrOZlSkpvn9zBA4y87HGlrPhnSPLkcLRnTPcXm2C/CNrOkQB2T7QKYv+IzCcmW0K974n3z9Q==}
 
   pg-types@2.2.0:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
@@ -7459,7 +7483,11 @@ snapshots:
 
   '@babel/helper-string-parser@7.25.9': {}
 
+  '@babel/helper-string-parser@7.27.1': {}
+
   '@babel/helper-validator-identifier@7.25.9': {}
+
+  '@babel/helper-validator-identifier@7.27.1': {}
 
   '@babel/helper-validator-option@7.25.9': {}
 
@@ -7471,6 +7499,10 @@ snapshots:
   '@babel/parser@7.27.0':
     dependencies:
       '@babel/types': 7.27.0
+
+  '@babel/parser@7.27.2':
+    dependencies:
+      '@babel/types': 7.27.1
 
   '@babel/plugin-syntax-jsx@7.25.9(@babel/core@7.26.10)':
     dependencies:
@@ -7514,6 +7546,11 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
+
+  '@babel/types@7.27.1':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
 
   '@badrap/valita@0.3.11': {}
 
@@ -10564,6 +10601,10 @@ snapshots:
     dependencies:
       '@types/node': 22.14.1
 
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.14.1
+
   '@typescript-eslint/eslint-plugin@8.31.0(@typescript-eslint/parser@8.31.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
@@ -10699,7 +10740,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.13':
     dependencies:
-      '@babel/parser': 7.27.0
+      '@babel/parser': 7.27.2
       '@vue/shared': 3.5.13
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -10712,7 +10753,7 @@ snapshots:
 
   '@vue/compiler-sfc@3.5.13':
     dependencies:
-      '@babel/parser': 7.27.0
+      '@babel/parser': 7.27.2
       '@vue/compiler-core': 3.5.13
       '@vue/compiler-dom': 3.5.13
       '@vue/compiler-ssr': 3.5.13
@@ -13375,10 +13416,10 @@ snapshots:
 
   perfect-debounce@1.0.0: {}
 
-  pg-cloudflare@1.2.0:
+  pg-cloudflare@1.2.5:
     optional: true
 
-  pg-connection-string@2.8.1:
+  pg-connection-string@2.9.0:
     optional: true
 
   pg-format-fix@1.0.5: {}
@@ -13387,15 +13428,15 @@ snapshots:
 
   pg-numeric@1.0.2: {}
 
-  pg-pool@3.9.1(pg@8.14.0):
+  pg-pool@3.10.0(pg@8.14.0):
     dependencies:
       pg: 8.14.0
     optional: true
 
-  pg-protocol@1.8.0: {}
-
-  pg-protocol@1.9.0:
+  pg-protocol@1.10.0:
     optional: true
+
+  pg-protocol@1.8.0: {}
 
   pg-types@2.2.0:
     dependencies:
@@ -13418,13 +13459,13 @@ snapshots:
 
   pg@8.14.0:
     dependencies:
-      pg-connection-string: 2.8.1
-      pg-pool: 3.9.1(pg@8.14.0)
-      pg-protocol: 1.9.0
+      pg-connection-string: 2.9.0
+      pg-pool: 3.10.0(pg@8.14.0)
+      pg-protocol: 1.10.0
       pg-types: 2.2.0
       pgpass: 1.0.5
     optionalDependencies:
-      pg-cloudflare: 1.2.0
+      pg-cloudflare: 1.2.5
     optional: true
 
   pgpass@1.0.5:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,7 +83,7 @@ importers:
         version: 15.15.0
       openai:
         specifier: ^4.81.0
-        version: 4.95.1(ws@8.18.1)(zod@3.24.2)
+        version: 4.95.1(ws@8.18.2)(zod@3.24.2)
       postcss:
         specifier: ^8.5.1
         version: 8.5.3
@@ -137,7 +137,7 @@ importers:
         version: 0.0.127
       braintrust:
         specifier: ^0.0.197
-        version: 0.0.197(openai@4.95.1(ws@8.18.1)(zod@3.24.2))(react@19.0.0)(solid-js@1.9.5)(sswr@2.2.0(svelte@5.26.2))(svelte@5.26.2)(vue@3.5.13(typescript@5.8.3))(zod@3.24.2)
+        version: 0.0.197(openai@4.95.1(ws@8.18.2)(zod@3.24.2))(react@19.0.0)(solid-js@1.9.5)(sswr@2.2.0(svelte@5.26.2))(svelte@5.26.2)(vue@3.5.13(typescript@5.8.3))(zod@3.24.2)
       drizzle-orm:
         specifier: ^0.39.0
         version: 0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)
@@ -147,6 +147,9 @@ importers:
       drizzle-valibot:
         specifier: ^0.4.1
         version: 0.4.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))(valibot@1.0.0(typescript@5.8.3))
+      effect:
+        specifier: ^3.13.10
+        version: 3.13.10
       neverthrow:
         specifier: ^8.2.0
         version: 8.2.0
@@ -156,6 +159,9 @@ importers:
       valibot:
         specifier: ^1.0.0
         version: 1.0.0(typescript@5.8.3)
+      ws:
+        specifier: ^8.18.2
+        version: 8.18.2
 
   packages/server/api: {}
 
@@ -269,6 +275,9 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      effect:
+        specifier: ^3.13.10
+        version: 3.13.10
       jose:
         specifier: ^6.0.10
         version: 6.0.10
@@ -314,6 +323,9 @@ importers:
       vinxi:
         specifier: 0.5.3
         version: 0.5.3(@types/node@22.14.1)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(typescript@5.8.3)(xml2js@0.6.2)(yaml@2.7.1)
+      ws:
+        specifier: ^8.18.2
+        version: 8.18.2
     devDependencies:
       '@types/js-cookie':
         specifier: ^3.0.6
@@ -7146,8 +7158,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.18.1:
-    resolution: {integrity: sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==}
+  ws@8.18.2:
+    resolution: {integrity: sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -8001,7 +8013,7 @@ snapshots:
     dependencies:
       duplexify: 4.1.3
       fastify-plugin: 5.0.1
-      ws: 8.18.1
+      ws: 8.18.2
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -9426,7 +9438,7 @@ snapshots:
       semver: 7.7.1
       tsx: 4.19.3
       url-pattern: 1.0.3
-      ws: 8.18.1
+      ws: 8.18.2
     transitivePeerDependencies:
       - '@75lb/nature'
       - bufferutil
@@ -9592,7 +9604,7 @@ snapshots:
       '@supabase/node-fetch': 2.6.15
       '@types/phoenix': 1.6.6
       '@types/ws': 8.18.0
-      ws: 8.18.1
+      ws: 8.18.2
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -10768,7 +10780,7 @@ snapshots:
     dependencies:
       humanize-ms: 1.2.1
 
-  ai@3.4.33(openai@4.95.1(ws@8.18.1)(zod@3.24.2))(react@19.0.0)(solid-js@1.9.5)(sswr@2.2.0(svelte@5.26.2))(svelte@5.26.2)(vue@3.5.13(typescript@5.8.3))(zod@3.24.2):
+  ai@3.4.33(openai@4.95.1(ws@8.18.2)(zod@3.24.2))(react@19.0.0)(solid-js@1.9.5)(sswr@2.2.0(svelte@5.26.2))(svelte@5.26.2)(vue@3.5.13(typescript@5.8.3))(zod@3.24.2):
     dependencies:
       '@ai-sdk/provider': 0.0.26
       '@ai-sdk/provider-utils': 1.0.22(zod@3.24.2)
@@ -10784,7 +10796,7 @@ snapshots:
       secure-json-parse: 2.7.0
       zod-to-json-schema: 3.24.3(zod@3.24.2)
     optionalDependencies:
-      openai: 4.95.1(ws@8.18.1)(zod@3.24.2)
+      openai: 4.95.1(ws@8.18.2)(zod@3.24.2)
       react: 19.0.0
       sswr: 2.2.0(svelte@5.26.2)
       svelte: 5.26.2
@@ -11070,13 +11082,13 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  braintrust@0.0.197(openai@4.95.1(ws@8.18.1)(zod@3.24.2))(react@19.0.0)(solid-js@1.9.5)(sswr@2.2.0(svelte@5.26.2))(svelte@5.26.2)(vue@3.5.13(typescript@5.8.3))(zod@3.24.2):
+  braintrust@0.0.197(openai@4.95.1(ws@8.18.2)(zod@3.24.2))(react@19.0.0)(solid-js@1.9.5)(sswr@2.2.0(svelte@5.26.2))(svelte@5.26.2)(vue@3.5.13(typescript@5.8.3))(zod@3.24.2):
     dependencies:
       '@ai-sdk/provider': 1.1.2
       '@braintrust/core': 0.0.84
       '@next/env': 14.2.28
       '@vercel/functions': 1.6.0
-      ai: 3.4.33(openai@4.95.1(ws@8.18.1)(zod@3.24.2))(react@19.0.0)(solid-js@1.9.5)(sswr@2.2.0(svelte@5.26.2))(svelte@5.26.2)(vue@3.5.13(typescript@5.8.3))(zod@3.24.2)
+      ai: 3.4.33(openai@4.95.1(ws@8.18.2)(zod@3.24.2))(react@19.0.0)(solid-js@1.9.5)(sswr@2.2.0(svelte@5.26.2))(svelte@5.26.2)(vue@3.5.13(typescript@5.8.3))(zod@3.24.2)
       argparse: 2.0.1
       chalk: 4.1.2
       cli-progress: 3.12.0
@@ -13250,7 +13262,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  openai@4.95.1(ws@8.18.1)(zod@3.24.2):
+  openai@4.95.1(ws@8.18.2)(zod@3.24.2):
     dependencies:
       '@types/node': 18.19.86
       '@types/node-fetch': 2.6.12
@@ -13260,7 +13272,7 @@ snapshots:
       formdata-node: 4.4.1
       node-fetch: 2.7.0
     optionalDependencies:
-      ws: 8.18.1
+      ws: 8.18.2
       zod: 3.24.2
     transitivePeerDependencies:
       - encoding
@@ -14838,7 +14850,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.18.1: {}
+  ws@8.18.2: {}
 
   xml2js@0.6.2:
     dependencies:


### PR DESCRIPTION
fairly big PR that introduces effect mostly for the server. main usages are of:
- Tagged Errors
- Effect type

Otherwise it typically executes a `runPromise` at the network boundary for now to avoid serialization for the time being. Later can solve this with effect schema and possibly effect rpc

Additional changes to solve editor perf wall that was hit:
- change method for declaring schema in drizzle from complex spread to barrel import. this solved most lsp perf issues