### PR TITLE
fix: balance card tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "packageManager": "pnpm@10.6.2",
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.22.0",
+    "@types/bun": "^1.2.15",
     "@ianvs/prettier-plugin-sort-imports": "^4.4.1",
     "@mistralai/mistralai": "^0.1.3",
     "@tailwindcss/vite": "^4.0.8",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -8,7 +8,8 @@
     "build": "vinxi build",
     "start": "vinxi start",
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint:fix": "eslint . --fix",
+    "test": "pnpm dlx sst shell -- bun test"
   },
   "dependencies": {
     "@blank/auth": "workspace:*",

--- a/packages/web/src/lib/participants.ts
+++ b/packages/web/src/lib/participants.ts
@@ -10,3 +10,27 @@ export function getPayerFromParticipants(
 ) {
   return participants.find((p) => p.role === "payer")?.userId;
 }
+
+export type MemberBalanceTuple = readonly [Member, number];
+
+// Custom sort order:
+// 1. positive balances first, descending
+// 2. negative balances next, descending by absolute value
+// 3. zero balances last
+export function compareParticipantsCustomOrder(
+  [_memberA, a]: MemberBalanceTuple,
+  [_memberB, b]: MemberBalanceTuple
+) {
+  if (a === b) return 0;
+
+  // deprioritize 0s (shift right)
+  if (a === 0 && b !== 0) return 1;
+  if (b === 0 && a !== 0) return -1;
+
+  // if both neg, prioritize higher abs values (shift left)
+  if (a < 0 && b < 0) return Math.abs(b) - Math.abs(a);
+
+  // this means we have a mix of pos/neg, or both pos
+  // so we just push biggest values left
+  return b - a;
+}

--- a/packages/web/src/pages/_protected/groups/$slug/@components/overview-cards.tsx
+++ b/packages/web/src/pages/_protected/groups/$slug/@components/overview-cards.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils";
 import { Member } from "@blank/zero";
 import { ComponentProps, PropsWithChildren } from "react";
 import { Button } from "@/components/ui/button";
+import { compareParticipantsCustomOrder } from "@/lib/participants";
 
 function formatUSD(amount: number) {
   return new Intl.NumberFormat("en-US", {
@@ -49,7 +50,7 @@ export function GroupCard(props: CardsProps) {
           <props.header />
         </CardTitle>
       </CardHeader>
-      <CardContent className="px-4 pt-0 pb-0 min-h-8">
+      <CardContent className="px-4 pt-0 pb-0 min-h-9">
         <props.content />
       </CardContent>
       {props.footer && (
@@ -88,13 +89,13 @@ type BalancesCardProps = {
 export function BalancesCard(props: BalancesCardProps) {
   const transformed = props.members
     .map((member) => [member, props.balance(member.userId)] as const)
-    .sort((tupleA) => compare(tupleA[1], -1, 0, 1));
+    .sort(compareParticipantsCustomOrder);
 
   return (
     <GroupCard
       header={() => "Balances"}
       content={() => (
-        <ul className="flex flex-col gap-1 max-h-24 overflow-y-auto">
+        <ul className="flex flex-col gap-1 max-h-24 overflow-y-auto pb-3">
           {transformed.map(([member, balance]) => (
             <li key={member.nickname}>
               <div className="flex justify-between items-center">
@@ -111,13 +112,13 @@ export function BalancesCard(props: BalancesCardProps) {
                     "text-sm font-medium",
                     compare(
                       balance,
-                      "text-blank-theme",
+                      "text-rose-400",
                       "text-muted-foreground",
-                      "text-rose-400"
+                      "text-blank-theme"
                     )
                   )}
                 >
-                  {`${compare(balance, "+", "", "-")} ${formatUSD(Math.abs(balance))}`}
+                  {`${compare(balance, "-", "", "+")} ${formatUSD(Math.abs(balance))}`}
                 </span>
               </div>
             </li>

--- a/packages/web/src/pages/api/sync.push.ts
+++ b/packages/web/src/pages/api/sync.push.ts
@@ -2,27 +2,10 @@ import { json } from "@tanstack/react-start";
 import { createAPIFileRoute } from "@tanstack/react-start/api";
 import { AuthTokens } from "@/server/utils";
 import { authenticate } from "@/server/auth/core";
-import { connectionProvider } from "@rocicorp/zero/pg";
-import { schema } from "@blank/zero";
-import { PushProcessor } from "@rocicorp/zero/pg";
-import { OpenAuthToken } from "@blank/auth/subjects";
-import { Resource } from "sst";
-import postgres from "postgres";
-import { createClientMutators } from "@/lib/client-mutators";
-
-export const processor = new PushProcessor(
-  schema,
-  connectionProvider(postgres(Resource.Database.connection))
-);
-
-// whenever this grows, we can move it into server/server-mutators/*
-export function createServerMutators(auth: OpenAuthToken | undefined) {
-  const clientMutators = createClientMutators(auth);
-
-  return {
-    ...clientMutators,
-  };
-}
+import {
+  createServerMutators,
+  processor,
+} from "@/server/lib/server-mutators.ts";
 
 export const APIRoute = createAPIFileRoute("/api/sync/push")({
   POST: async ({ request }) => {

--- a/packages/web/src/server/lib/server-mutators.ts/index.ts
+++ b/packages/web/src/server/lib/server-mutators.ts/index.ts
@@ -1,0 +1,20 @@
+import { createClientMutators } from "@/lib/client-mutators";
+import { OpenAuthToken } from "@blank/auth/subjects";
+import { schema } from "@blank/zero";
+import { connectionProvider, PushProcessor } from "@rocicorp/zero/pg";
+import postgres from "postgres";
+import { Resource } from "sst";
+
+export const processor = new PushProcessor(
+  schema,
+  connectionProvider(postgres(Resource.Database.connection))
+);
+
+// whenever this grows, we can break it out the same way as client-mutators
+export function createServerMutators(auth: OpenAuthToken | undefined) {
+  const clientMutators = createClientMutators(auth);
+
+  return {
+    ...clientMutators,
+  };
+}

--- a/packages/web/src/tests/participant.spec.ts
+++ b/packages/web/src/tests/participant.spec.ts
@@ -1,18 +1,143 @@
-import { describe, it, expect } from "node:assert";
 import { Member } from "@blank/core/modules/member/schema";
-import { Participant } from "@blank/zero";
-import { getPayerFromParticipants } from "@/lib/participants";
+import {
+  compareParticipantsCustomOrder,
+  MemberBalanceTuple,
+} from "@/lib/participants";
+import { describe, it, expect } from "bun:test";
 
+// sort order:
+// 1. positive balances first, descending
+// 2. negative balances first, descending by absolute value
+// 3. zero balances last
+const MEMBER: Member = {
+  groupId: Date.now().toString(),
+  userId: Date.now().toString(),
+  nickname: "MOCK_USER",
+};
 
+function sortWithTransformations(input: number[]) {
+  const toMembers = (arr: number[]) =>
+    arr.map((balance) => [MEMBER, balance] as const);
+  const fromMembers = (arr: MemberBalanceTuple[]) =>
+    arr.map(([_member, balance]) => balance);
 
-describe("participants", () => {
-  it("should create a participant", () => {
-      const participants: Participant[] = [
-        {
-          userId: "123",
-          groupId: "456",
-        },
-      ];
-   });
+  const asParticipants = toMembers(input);
+  const sorted = asParticipants.sort(compareParticipantsCustomOrder);
+  const asBalances = fromMembers(sorted);
+
+  return asBalances;
+}
+
+describe("Sort participants by balance in custom sort order", () => {
+  const mixed: { in: number[]; out: number[] }[] = [
+    {
+      in: [100, -100, 0],
+      out: [100, -100, 0],
+    },
+    {
+      in: [100, -100, 0, 50, -50, 0],
+      out: [100, 50, -100, -50, 0, 0],
+    },
+    {
+      in: [0, -100, 100, 10, 40, -50, 0],
+      out: [100, 40, 10, -100, -50, 0, 0],
+    },
+    {
+      in: [1983, -2, 381, 1000, 1002, -1, 0, 0, 1983],
+      out: [1983, 1983, 1002, 1000, 381, -2, -1, 0, 0],
+    },
+  ];
+
+  it.each(mixed)(
+    "Should sort correctly when balances inputs are mixed",
+    ({ in: INPUT, out: EXPECTED }) => {
+      const balances = sortWithTransformations(INPUT);
+
+      expect(balances).toEqual(EXPECTED);
+    }
+  );
+
+  it("Should sort correctly when balances are all positive", () => {
+    const INPUT = [4321, 157, 2999, 4800, 75, 2048];
+    const EXPECTED = [4800, 4321, 2999, 2048, 157, 75];
+
+    const balances = sortWithTransformations(INPUT);
+
+    expect(balances).toEqual(EXPECTED);
+  });
+
+  it("Should sort correctly when balances are all negative", () => {
+    const INPUT = [-487, -3201, -59, -4021, -1500, -2999];
+    const EXPECTED = [-4021, -3201, -2999, -1500, -487, -59];
+
+    const balances = sortWithTransformations(INPUT);
+
+    expect(balances).toEqual(EXPECTED);
+  });
+
+  it("Should sort correctly when balances are all zero", () => {
+    const INPUT = [0, 0, 0, 0, 0, 0];
+    const EXPECTED = [0, 0, 0, 0, 0, 0];
+
+    const balances = sortWithTransformations(INPUT);
+
+    expect(balances).toEqual(EXPECTED);
+  });
+
+  it("Should sort correctly when balances has 1 item", () => {
+    const INPUT = [100];
+    const EXPECTED = [100];
+
+    const balances = sortWithTransformations(INPUT);
+
+    expect(balances).toEqual(EXPECTED);
+  });
+
+  it("Should sort correctly when balances has 2 items", () => {
+    const INPUT = [100, -100];
+    const EXPECTED = [100, -100];
+
+    const balances = sortWithTransformations(INPUT);
+
+    expect(balances).toEqual(EXPECTED);
+  });
+
+  it("Should sort correctly when balances have duplicate values", () => {
+    const INPUT = [100, 100, -100, -100, 0, 0];
+    const EXPECTED = [100, 100, -100, -100, 0, 0];
+
+    const balances = sortWithTransformations(INPUT);
+    expect(balances).toEqual(EXPECTED);
+  });
+
+  it("Should sort correctly with large and small numbers", () => {
+    const INPUT = [Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER, 0, 1, -1];
+    const EXPECTED = [
+      Number.MAX_SAFE_INTEGER,
+      1,
+      Number.MIN_SAFE_INTEGER,
+      -1,
+      0,
+    ];
+
+    const balances = sortWithTransformations(INPUT);
+    expect(balances).toEqual(EXPECTED);
+  });
+
+  it("Should sort correctly with floating point numbers", () => {
+    const INPUT = [1.5, -2.3, 0, 3.7, -0.1];
+    const EXPECTED = [3.7, 1.5, -2.3, -0.1, 0];
+
+    const balances = sortWithTransformations(INPUT);
+    expect(balances).toEqual(EXPECTED);
+  });
+
+  it("Should sort correctly with negative zero and zero", () => {
+    const INPUT = [0, -0, 1, -1];
+    // JS treats 0 and -0 as equal in sort, so both will be at the end
+    const EXPECTED = [1, -1, 0, -0];
+
+    const balances = sortWithTransformations(INPUT);
+    expect(balances).toEqual(EXPECTED);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@types/aws-lambda':
         specifier: 8.10.147
         version: 8.10.147
+      '@types/bun':
+        specifier: ^1.2.15
+        version: 1.2.15
       '@types/node':
         specifier: ^22.15.29
         version: 22.15.29
@@ -140,13 +143,13 @@ importers:
         version: 0.0.197(openai@4.95.1(ws@8.18.2)(zod@3.24.2))(react@19.0.0)(solid-js@1.9.5)(sswr@2.2.0(svelte@5.26.2))(svelte@5.26.2)(vue@3.5.13(typescript@5.8.3))(zod@3.24.2)
       drizzle-orm:
         specifier: ^0.39.3
-        version: 0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)
+        version: 0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)
       drizzle-seed:
         specifier: ^0.3.1
-        version: 0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))
+        version: 0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5))
       drizzle-valibot:
         specifier: ^0.4.1
-        version: 0.4.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))(valibot@1.0.0(typescript@5.8.3))
+        version: 0.4.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5))(valibot@1.0.0(typescript@5.8.3))
       effect:
         specifier: ^3.13.10
         version: 3.13.10
@@ -249,7 +252,7 @@ importers:
         version: 1.1.8(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@tanstack/react-form':
         specifier: ^1.9.0
-        version: 1.9.0(b2523a7df1108e665f2bf9ec512fb8d4)
+        version: 1.9.0(b33dccc1977f5747739a3ba36d85113f)
       '@tanstack/react-query':
         specifier: ^5.74.4
         version: 5.74.4(react@19.0.0)
@@ -264,7 +267,7 @@ importers:
         version: 1.117.1(@tanstack/react-query@5.74.4(react@19.0.0))(@tanstack/react-router@1.120.13(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@tanstack/router-core@1.120.13)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@tanstack/react-start':
         specifier: ^1.120.13
-        version: 1.120.13(@tanstack/react-router@1.120.13(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(vite@6.3.2(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(xml2js@0.6.2)(yaml@2.7.1)
+        version: 1.120.13(@tanstack/react-router@1.120.13(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(vite@6.3.2(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(xml2js@0.6.2)(yaml@2.7.1)
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -333,7 +336,7 @@ importers:
         version: 1.0.0(typescript@5.8.3)
       vinxi:
         specifier: 0.5.3
-        version: 0.5.3(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(xml2js@0.6.2)(yaml@2.7.1)
+        version: 0.5.3(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(xml2js@0.6.2)(yaml@2.7.1)
       ws:
         specifier: ^8.18.2
         version: 8.18.2
@@ -4154,6 +4157,9 @@ packages:
   '@types/braces@3.0.5':
     resolution: {integrity: sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==}
 
+  '@types/bun@1.2.15':
+    resolution: {integrity: sha512-U1ljPdBEphF0nw1MIk0hI7kPg7dFdPyM7EenHsp6W5loNHl7zqy6JQf/RKCgnUn2KDzUpkBwHPnEJEjII594bA==}
+
   '@types/diff-match-patch@1.0.36':
     resolution: {integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==}
 
@@ -4709,6 +4715,9 @@ packages:
   builtin-modules@3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
     engines: {node: '>=6'}
+
+  bun-types@1.2.15:
+    resolution: {integrity: sha512-NarRIaS+iOaQU1JPfyKhZm4AsUOrwUOqRNHY0XxI8GI8jYxiLXLcdjYMG9UKS+fwWasc1uw1htV9AX24dD+p4w==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -12149,7 +12158,7 @@ snapshots:
 
   '@tanstack/query-core@5.74.4': {}
 
-  '@tanstack/react-form@1.9.0(b2523a7df1108e665f2bf9ec512fb8d4)':
+  '@tanstack/react-form@1.9.0(b33dccc1977f5747739a3ba36d85113f)':
     dependencies:
       '@tanstack/form-core': 1.9.0
       '@tanstack/react-store': 0.7.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -12157,8 +12166,8 @@ snapshots:
       devalue: 5.1.1
       react: 19.0.0
     optionalDependencies:
-      '@tanstack/react-start': 1.120.13(@tanstack/react-router@1.120.13(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(vite@6.3.2(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(xml2js@0.6.2)(yaml@2.7.1)
-      vinxi: 0.5.3(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(xml2js@0.6.2)(yaml@2.7.1)
+      '@tanstack/react-start': 1.120.13(@tanstack/react-router@1.120.13(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(vite@6.3.2(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(xml2js@0.6.2)(yaml@2.7.1)
+      vinxi: 0.5.3(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(xml2js@0.6.2)(yaml@2.7.1)
     transitivePeerDependencies:
       - react-dom
 
@@ -12210,7 +12219,7 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  '@tanstack/react-start-client@1.120.13(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(xml2js@0.6.2)(yaml@2.7.1)':
+  '@tanstack/react-start-client@1.120.13(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(xml2js@0.6.2)(yaml@2.7.1)':
     dependencies:
       '@tanstack/react-router': 1.120.13(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@tanstack/router-core': 1.120.13
@@ -12221,7 +12230,7 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
-      vinxi: 0.5.3(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(xml2js@0.6.2)(yaml@2.7.1)
+      vinxi: 0.5.3(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(xml2js@0.6.2)(yaml@2.7.1)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -12265,7 +12274,7 @@ snapshots:
       - xml2js
       - yaml
 
-  '@tanstack/react-start-config@1.120.13(@tanstack/react-router@1.120.13(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(vite@6.3.2(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(xml2js@0.6.2)(yaml@2.7.1)':
+  '@tanstack/react-start-config@1.120.13(@tanstack/react-router@1.120.13(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(vite@6.3.2(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(xml2js@0.6.2)(yaml@2.7.1)':
     dependencies:
       '@tanstack/react-start-plugin': 1.115.0(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
       '@tanstack/router-core': 1.120.13
@@ -12275,11 +12284,11 @@ snapshots:
       '@tanstack/start-server-functions-handler': 1.120.13
       '@vitejs/plugin-react': 4.5.0(vite@6.3.2(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))
       import-meta-resolve: 4.1.0
-      nitropack: 2.11.12(aws4fetch@1.0.20)(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))(xml2js@0.6.2)
+      nitropack: 2.11.12(aws4fetch@1.0.20)(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5))(xml2js@0.6.2)
       ofetch: 1.4.1
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      vinxi: 0.5.3(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(xml2js@0.6.2)(yaml@2.7.1)
+      vinxi: 0.5.3(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(xml2js@0.6.2)(yaml@2.7.1)
       vite: 6.3.2(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
       zod: 3.25.46
     transitivePeerDependencies:
@@ -12357,11 +12366,11 @@ snapshots:
       - tsx
       - yaml
 
-  '@tanstack/react-start-router-manifest@1.120.13(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(xml2js@0.6.2)(yaml@2.7.1)':
+  '@tanstack/react-start-router-manifest@1.120.13(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(xml2js@0.6.2)(yaml@2.7.1)':
     dependencies:
       '@tanstack/router-core': 1.120.13
       tiny-invariant: 1.3.3
-      vinxi: 0.5.3(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(xml2js@0.6.2)(yaml@2.7.1)
+      vinxi: 0.5.3(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(xml2js@0.6.2)(yaml@2.7.1)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -12420,13 +12429,13 @@ snapshots:
       tiny-warning: 1.0.3
       unctx: 2.4.1
 
-  '@tanstack/react-start@1.120.13(@tanstack/react-router@1.120.13(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(vite@6.3.2(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(xml2js@0.6.2)(yaml@2.7.1)':
+  '@tanstack/react-start@1.120.13(@tanstack/react-router@1.120.13(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(vite@6.3.2(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(xml2js@0.6.2)(yaml@2.7.1)':
     dependencies:
-      '@tanstack/react-start-client': 1.120.13(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(xml2js@0.6.2)(yaml@2.7.1)
-      '@tanstack/react-start-config': 1.120.13(@tanstack/react-router@1.120.13(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(vite@6.3.2(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(xml2js@0.6.2)(yaml@2.7.1)
-      '@tanstack/react-start-router-manifest': 1.120.13(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(xml2js@0.6.2)(yaml@2.7.1)
+      '@tanstack/react-start-client': 1.120.13(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(xml2js@0.6.2)(yaml@2.7.1)
+      '@tanstack/react-start-config': 1.120.13(@tanstack/react-router@1.120.13(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(vite@6.3.2(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1))(xml2js@0.6.2)(yaml@2.7.1)
+      '@tanstack/react-start-router-manifest': 1.120.13(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(xml2js@0.6.2)(yaml@2.7.1)
       '@tanstack/react-start-server': 1.120.13(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@tanstack/start-api-routes': 1.120.13(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(xml2js@0.6.2)(yaml@2.7.1)
+      '@tanstack/start-api-routes': 1.120.13(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(xml2js@0.6.2)(yaml@2.7.1)
       '@tanstack/start-server-functions-client': 1.120.13(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
       '@tanstack/start-server-functions-handler': 1.120.13
       '@tanstack/start-server-functions-server': 1.119.2(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
@@ -12644,11 +12653,11 @@ snapshots:
       - tsx
       - yaml
 
-  '@tanstack/start-api-routes@1.120.13(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(xml2js@0.6.2)(yaml@2.7.1)':
+  '@tanstack/start-api-routes@1.120.13(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(xml2js@0.6.2)(yaml@2.7.1)':
     dependencies:
       '@tanstack/router-core': 1.120.13
       '@tanstack/start-server-core': 1.120.13
-      vinxi: 0.5.3(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(xml2js@0.6.2)(yaml@2.7.1)
+      vinxi: 0.5.3(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(xml2js@0.6.2)(yaml@2.7.1)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -12944,6 +12953,10 @@ snapshots:
       '@babel/types': 7.27.0
 
   '@types/braces@3.0.5': {}
+
+  '@types/bun@1.2.15':
+    dependencies:
+      bun-types: 1.2.15
 
   '@types/diff-match-patch@1.0.36': {}
 
@@ -13756,6 +13769,10 @@ snapshots:
 
   builtin-modules@3.3.0: {}
 
+  bun-types@1.2.15:
+    dependencies:
+      '@types/node': 22.15.29
+
   bytes@3.1.2: {}
 
   c12@3.0.2(magicast@0.3.5):
@@ -14094,13 +14111,13 @@ snapshots:
       '@deno/shim-deno': 0.19.2
       undici-types: 5.28.4
 
-  db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)):
+  db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)):
     optionalDependencies:
-      drizzle-orm: 0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)
+      drizzle-orm: 0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)
 
-  db0@0.3.2(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)):
+  db0@0.3.2(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)):
     optionalDependencies:
-      drizzle-orm: 0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)
+      drizzle-orm: 0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)
 
   debug@2.6.9:
     dependencies:
@@ -14258,23 +14275,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5):
+  drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5):
     optionalDependencies:
       '@neondatabase/serverless': 0.10.4
       '@opentelemetry/api': 1.9.0
       '@types/pg': 8.11.6
+      bun-types: 1.2.15
       pg: 8.14.0
       postgres: 3.4.5
 
-  drizzle-seed@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)):
+  drizzle-seed@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)):
     dependencies:
       pure-rand: 6.1.0
     optionalDependencies:
-      drizzle-orm: 0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)
+      drizzle-orm: 0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)
 
-  drizzle-valibot@0.4.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))(valibot@1.0.0(typescript@5.8.3)):
+  drizzle-valibot@0.4.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5))(valibot@1.0.0(typescript@5.8.3)):
     dependencies:
-      drizzle-orm: 0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)
+      drizzle-orm: 0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)
       valibot: 1.0.0(typescript@5.8.3)
 
   dunder-proto@1.0.1:
@@ -16021,7 +16039,7 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
-  nitropack@2.11.12(aws4fetch@1.0.20)(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))(xml2js@0.6.2):
+  nitropack@2.11.12(aws4fetch@1.0.20)(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5))(xml2js@0.6.2):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.0
       '@netlify/functions': 3.1.10(rollup@4.41.1)
@@ -16043,7 +16061,7 @@ snapshots:
       cookie-es: 2.0.0
       croner: 9.0.0
       crossws: 0.3.5
-      db0: 0.3.2(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))
+      db0: 0.3.2(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5))
       defu: 6.1.4
       destr: 2.0.5
       dot-prop: 9.0.0
@@ -16089,7 +16107,7 @@ snapshots:
       unenv: 2.0.0-rc.17
       unimport: 5.0.1
       unplugin-utils: 0.2.4
-      unstorage: 1.16.0(aws4fetch@1.0.20)(db0@0.3.2(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)))(ioredis@5.6.1)
+      unstorage: 1.16.0(aws4fetch@1.0.20)(db0@0.3.2(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)))(ioredis@5.6.1)
       untyped: 2.0.0
       unwasm: 0.3.9
       youch: 4.1.0-beta.8
@@ -16123,7 +16141,7 @@ snapshots:
       - supports-color
       - uploadthing
 
-  nitropack@2.11.6(aws4fetch@1.0.20)(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))(typescript@5.8.3)(xml2js@0.6.2):
+  nitropack@2.11.6(aws4fetch@1.0.20)(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5))(typescript@5.8.3)(xml2js@0.6.2):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.3.4
       '@netlify/functions': 3.0.0
@@ -16146,7 +16164,7 @@ snapshots:
       cookie-es: 2.0.0
       croner: 9.0.0
       crossws: 0.3.4
-      db0: 0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))
+      db0: 0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5))
       defu: 6.1.4
       destr: 2.0.3
       dot-prop: 9.0.0
@@ -16194,7 +16212,7 @@ snapshots:
       unenv: 2.0.0-rc.14
       unimport: 4.1.2
       unplugin-utils: 0.2.4
-      unstorage: 1.15.0(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)))(ioredis@5.6.0)
+      unstorage: 1.15.0(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)))(ioredis@5.6.0)
       untyped: 2.0.0
       unwasm: 0.3.9
       youch: 4.1.0-beta.6
@@ -17880,7 +17898,7 @@ snapshots:
       picomatch: 4.0.2
       webpack-virtual-modules: 0.6.2
 
-  unstorage@1.15.0(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)))(ioredis@5.6.0):
+  unstorage@1.15.0(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)))(ioredis@5.6.0):
     dependencies:
       anymatch: 3.1.3
       chokidar: 4.0.3
@@ -17892,10 +17910,10 @@ snapshots:
       ufo: 1.5.4
     optionalDependencies:
       aws4fetch: 1.0.20
-      db0: 0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))
+      db0: 0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5))
       ioredis: 5.6.0
 
-  unstorage@1.16.0(aws4fetch@1.0.20)(db0@0.3.2(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)))(ioredis@5.6.1):
+  unstorage@1.16.0(aws4fetch@1.0.20)(db0@0.3.2(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)))(ioredis@5.6.1):
     dependencies:
       anymatch: 3.1.3
       chokidar: 4.0.3
@@ -17907,7 +17925,7 @@ snapshots:
       ufo: 1.6.1
     optionalDependencies:
       aws4fetch: 1.0.20
-      db0: 0.3.2(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))
+      db0: 0.3.2(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5))
       ioredis: 5.6.1
 
   untun@0.1.3:
@@ -18018,7 +18036,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vinxi@0.5.3(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(xml2js@0.6.2)(yaml@2.7.1):
+  vinxi@0.5.3(@types/node@22.15.29)(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)))(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5))(ioredis@5.6.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(typescript@5.8.3)(xml2js@0.6.2)(yaml@2.7.1):
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.10)
@@ -18040,7 +18058,7 @@ snapshots:
       hookable: 5.5.3
       http-proxy: 1.18.1
       micromatch: 4.0.8
-      nitropack: 2.11.6(aws4fetch@1.0.20)(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5))(typescript@5.8.3)(xml2js@0.6.2)
+      nitropack: 2.11.6(aws4fetch@1.0.20)(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5))(typescript@5.8.3)(xml2js@0.6.2)
       node-fetch-native: 1.6.6
       path-to-regexp: 6.3.0
       pathe: 1.1.2
@@ -18051,7 +18069,7 @@ snapshots:
       ufo: 1.5.4
       unctx: 2.4.1
       unenv: 1.10.0
-      unstorage: 1.15.0(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(pg@8.14.0)(postgres@3.4.5)))(ioredis@5.6.0)
+      unstorage: 1.15.0(aws4fetch@1.0.20)(db0@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.15)(pg@8.14.0)(postgres@3.4.5)))(ioredis@5.6.0)
       vite: 6.3.2(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.4)(yaml@2.7.1)
       zod: 3.24.2
     transitivePeerDependencies:


### PR DESCRIPTION
fixes:
- member balance card sorting:
  - positives descending (1k, 500, 25, ...)
  - negatives descending by abs. value (-1k, -500, -25, ...)
  - 0's
  eg.: [5k, 1.5k, 500, -15k, -286, 0, 0, 0]
- adds testing for ^ with bun:test
- member balance h-8 tweak so for groups w/ members <= 3, card size doesn't change

note: this is kinda annoying bc now the project has:
    - node: runtime
    - pnpm: package manager
    - bun: test runner
    - tsx: some other scripting needs
    - should converge bun and tsx here and use bun for native ts support in scripts, and maybe move to bun package manager too to simplify this and then have: node runtime, bun everything else

todo:
- need to solve in-card scroll for groups w/ > 3 members
    - accordion?
    - max-h w/ scroll?