### PR TITLE
fix: update balance calculation to account for payer split

### DIFF
--- a/packages/web/src/pages/_protected/groups/$slug/page.tsx
+++ b/packages/web/src/pages/_protected/groups/$slug/page.tsx
@@ -27,9 +27,15 @@ function createBalanceMap(expenses: ExpenseWithParticipants[]) {
       expense.participants.forEach((p) => {
         const balance = map.get(p.userId) ?? 0;
 
-        const delta = p.role === "payer" ? 1 : -1;
-        const split = p.split;
+        // split: owed = (1 - split) * amount, owe = (split) * amount
+        // delta: owed = positive (they're owed), owe = negative (they owe)
+        const [split, delta] =
+          p.role === "payer" ? [1 - p.split, 1] : [p.split, -1];
 
+        // For each participant, update their balance:
+        //   - If payer: add their share of the amount they are owed (positive)
+        //   - If not payer: subtract the share they owe (negative)
+        //   - Formula: balance += delta (direction) * split (share) * amount
         map.set(p.userId, balance + delta * split * expense.amount);
       });
     });


### PR DESCRIPTION
in balance overview calculation, the payer's split is the inverse of the participant split (as we show what they are owed, so we need to calculate the share they're NOT responsible for, and then that is part of what they're owed). this adds that