### PR TITLE
feat: handle missing expense fields (due to member deletion)

### DIFF
--- a/packages/web/src/components/form/fields.tsx
+++ b/packages/web/src/components/form/fields.tsx
@@ -253,7 +253,7 @@ export const SheetDateField = (props: SheetDateFieldProps) => {
             disabled={rest.inputProps?.disabled ?? false}
             variant="secondary"
             className={cn(
-              "w-full justify-start text-left font-normal lowercase bg-accent/50 border border-border/50 text-foreground h-10",
+              "justify-start bg-accent/50 border-border/50 border-[1.5px] text-foreground hover:bg-secondary/80 placeholder:text-muted-foreground/60 h-10 w-full",
               !field.state.value && "text-muted-foreground",
             )}
           >

--- a/packages/web/src/components/ui/tooltip.tsx
+++ b/packages/web/src/components/ui/tooltip.tsx
@@ -38,8 +38,11 @@ function TooltipContent({
   className,
   sideOffset = 0,
   children,
+  arrowProps,
   ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+}: React.ComponentProps<typeof TooltipPrimitive.Content> & {
+  arrowProps?: React.ComponentProps<typeof TooltipPrimitive.Arrow>;
+}) {
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Content
@@ -52,7 +55,12 @@ function TooltipContent({
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+        <TooltipPrimitive.Arrow
+          className={cn(
+            "bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_0.5px)] rotate-45 rounded-0",
+            arrowProps?.className,
+          )}
+        />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   );

--- a/packages/web/src/lib/balances.ts
+++ b/packages/web/src/lib/balances.ts
@@ -2,6 +2,7 @@ import { ExpenseWithParticipants } from "@/pages/_protected/groups/$slug_id/page
 import { Member } from "@blank/zero";
 import { Match, Number, pipe } from "effect";
 import { fraction } from "./utils";
+import { ParticipantWithMember } from "./participants";
 
 export type MemberWithBalance = Member & { balance: number };
 export type Balances = {
@@ -118,4 +119,18 @@ export function calculateSettlements(
   }
 
   return settlements;
+}
+
+export function checkExpenseSplitValidity(
+  participants: ParticipantWithMember[],
+) {
+  const ERROR_MARGIN = 1e-10;
+
+  const split = participants.reduce((sum, participant) => {
+    const [num, denom] = participant.split;
+
+    return sum + num / denom;
+  }, 0);
+
+  return Math.abs(split - 1) < ERROR_MARGIN;
 }

--- a/packages/web/src/pages/_protected/@create-expense.dialog.tsx
+++ b/packages/web/src/pages/_protected/@create-expense.dialog.tsx
@@ -87,7 +87,7 @@ export function CreateExpenseDialog(props: PropsWithChildren) {
   const params = useGroupFromSearch();
 
   const create = useCreateExpense(
-    userDefaultGroup.data?.id ?? params?.id ?? "",
+    params?.id ?? userDefaultGroup.data?.id ?? "",
   );
 
   const route = SearchRoute.useSearchRoute({

--- a/packages/web/src/pages/_protected/groups/$slug_id/@expense.sheet.tsx
+++ b/packages/web/src/pages/_protected/groups/$slug_id/@expense.sheet.tsx
@@ -62,24 +62,22 @@ function useConfirmDeleteExpense(
   });
 }
 
-function useConfirmSettleExpense(
-  expense: ExpenseWithParticipants,
-  userId: string,
-  settleMutation: (opts: UpdateExpenseOptions) => Promise<void>,
-  leave: () => void,
-) {
-  const payer = getPayerFromParticipants(expense.participants);
-  if (!payer) {
-    throw new Error("Payer not found");
-  }
+type UseConfirmSettleExpense = {
+  expense: ExpenseWithParticipants;
+  payer: ParticipantWithMember | undefined;
+  userId: string;
+  settleMutation: (opts: UpdateExpenseOptions) => Promise<void>;
+  leave: () => void;
+};
 
+function useConfirmSettleExpense(opts: UseConfirmSettleExpense) {
   const getSettleUpSentence = (
     p1: ParticipantWithMember,
     p2: ParticipantWithMember,
     amount: number,
   ) => {
-    const payerIsCurrentUser = p1.userId === userId;
-    const payeeIsCurrentUser = p2.userId === userId;
+    const payerIsCurrentUser = p1.userId === opts.userId;
+    const payeeIsCurrentUser = p2.userId === opts.userId;
 
     return [
       payerIsCurrentUser ? "You" : p1.member?.nickname,
@@ -94,42 +92,61 @@ function useConfirmSettleExpense(
     subtitle: false,
     description: {
       type: "jsx",
-      value: () => (
-        <div className="space-y-4">
-          <DialogDescription>
-            This will settle and archive the expense. Be sure to settle up with
-            all participants. The following transaction must be made:
-          </DialogDescription>
-          <ul className="list-inside text-sm text-foreground space-y-1.5 mb-4">
-            {expense.participants
-              .filter((p) => p.role === "participant")
-              .map((p) => (
-                <li
-                  key={p.userId}
-                  className="flex items-center justify-between gap-2 mx-2 text-foreground lowercase"
-                >
+      value: () => {
+        const payer = opts.payer;
+        console.log("PAYER: ", payer);
+
+        if (!payer) {
+          throw new Error("Can not settle expense without a payer");
+        }
+
+        return (
+          <div className="space-y-4">
+            <DialogDescription>
+              This will settle and archive the expense. Be sure to settle up
+              with all participants. The following transaction must be made:
+            </DialogDescription>
+            <ul className="list-inside text-sm text-foreground space-y-1.5 mb-4">
+              {opts.expense.participants.length > 1 ? (
+                opts.expense.participants
+                  .filter((p) => p.role === "participant")
+                  .map((p) => (
+                    <li
+                      key={p.userId}
+                      className="flex items-center justify-between gap-2 mx-2 text-foreground lowercase"
+                    >
+                      <ChevronRight className="size-3.5" />
+                      {getSettleUpSentence(
+                        p,
+                        payer,
+                        fraction(p.split).apply(opts.expense.amount),
+                      )}
+                      <span className="text-blank-theme ml-auto font-bold">
+                        [{Math.round(fraction(p.split).percent()).toString()}%]
+                      </span>
+                    </li>
+                  ))
+              ) : (
+                <div className="flex items-center gap-2 mx-2 text-foreground lowercase">
                   <ChevronRight className="size-3.5" />
-                  {getSettleUpSentence(
-                    p,
-                    payer,
-                    fraction(p.split).apply(expense.amount),
-                  )}
-                  <span className="text-blank-theme ml-auto font-bold">
-                    [{Math.round(fraction(p.split).percent()).toString()}%]
-                  </span>
-                </li>
-              ))}
-          </ul>
-        </div>
-      ),
+                  <p>
+                    {payer.member?.nickname} is the only participant, no
+                    payments required
+                  </p>
+                </div>
+              )}
+            </ul>
+          </div>
+        );
+      },
     },
     confirm: "Settle",
     confirmVariant: "theme",
     onConfirm: async () => {
       return withToast({
         promise: () => {
-          return settleMutation({
-            expenseId: expense.id,
+          return opts.settleMutation({
+            expenseId: opts.expense.id,
             updates: { expense: { status: "settled" } },
           });
         },
@@ -142,7 +159,7 @@ function useConfirmSettleExpense(
           success: "!bg-secondary !border-border",
         },
       }).then(() => {
-        leave();
+        opts.leave();
       });
     },
   });
@@ -270,6 +287,8 @@ export function ExpenseSheet(props: ExpenseSheetProps) {
   const route = SearchRoute.useSearchRoute();
   const active = props.expense;
 
+  const payer = getPayerFromParticipants(active.participants);
+
   const mutators = useMutators();
   const form = useForm(active, mutators.expense.update, route.close);
   const deleteExpense = useConfirmDeleteExpense(
@@ -277,12 +296,17 @@ export function ExpenseSheet(props: ExpenseSheetProps) {
     mutators.expense.delete,
     route.close,
   );
-  const settleExpense = useConfirmSettleExpense(
-    active,
-    auth.user.id,
-    mutators.expense.update,
-    route.close,
-  );
+
+  console.log("[payer]", payer);
+
+  const settleExpense = useConfirmSettleExpense({
+    expense: active,
+    payer: payer,
+    userId: auth.user.id,
+    settleMutation: mutators.expense.update,
+    leave: route.close,
+  });
+
   const unsettleExpense = () => {
     route.close();
     void withToast({
@@ -420,6 +444,7 @@ export function ExpenseSheet(props: ExpenseSheetProps) {
                 {active.status === "active" ? (
                   <form.api.SettleButton
                     className="col-span-1 h-min"
+                    disabled={!payer}
                     onClick={settleExpense.confirm}
                   >
                     Settle
@@ -427,6 +452,7 @@ export function ExpenseSheet(props: ExpenseSheetProps) {
                 ) : (
                   <form.api.SettleButton
                     className="col-span-1 h-auto"
+                    disabled={!payer}
                     onClick={() => unsettleExpense()}
                   >
                     Unsettle

--- a/packages/web/src/pages/_protected/groups/$slug_id/@expense.sheet.tsx
+++ b/packages/web/src/pages/_protected/groups/$slug_id/@expense.sheet.tsx
@@ -94,7 +94,6 @@ function useConfirmSettleExpense(opts: UseConfirmSettleExpense) {
       type: "jsx",
       value: () => {
         const payer = opts.payer;
-        console.log("PAYER: ", payer);
 
         if (!payer) {
           throw new Error("Can not settle expense without a payer");
@@ -296,8 +295,6 @@ export function ExpenseSheet(props: ExpenseSheetProps) {
     mutators.expense.delete,
     route.close,
   );
-
-  console.log("[payer]", payer);
 
   const settleExpense = useConfirmSettleExpense({
     expense: active,

--- a/packages/web/src/pages/_protected/page.tsx
+++ b/packages/web/src/pages/_protected/page.tsx
@@ -17,6 +17,7 @@ import { positions } from "@/components/form/fields";
 import { useUserDefaultGroup } from "./@data/users";
 import { TaggedError } from "@blank/core/lib/effect/index";
 import { Group } from "@blank/zero";
+import { useGroupListByUserId } from "./@data/groups";
 
 class DataFetchingError extends TaggedError("DataFetchingError") {}
 
@@ -204,12 +205,15 @@ function ExpenseForm(props: ExpenseFormProps) {
 
 function HomeRoute() {
   const authentication = useAuthentication();
-  const userDefaultGroup = useUserDefaultGroup(authentication.user.id);
-  console.log(userDefaultGroup.status);
+  const defaultGroup = useUserDefaultGroup(authentication.user.id);
+  const groupsList = useGroupListByUserId(authentication.user.id);
 
-  if (userDefaultGroup.status === "loading") return <States.Loading />;
-  if (userDefaultGroup.status === "not-found") {
-    throw new DataFetchingError("Could not load user preferences");
+  if (defaultGroup.status === "loading" || groupsList.status === "loading") {
+    return <States.Loading />;
+  }
+
+  if (groupsList.status === "empty") {
+    throw new DataFetchingError("Could not load you groups");
   }
 
   return (
@@ -236,7 +240,9 @@ function HomeRoute() {
           </h2>
 
           <div className="border-6 rounded-md border-background">
-            <ExpenseForm defaultGroup={userDefaultGroup.data} />
+            <ExpenseForm
+              defaultGroup={defaultGroup.data ?? groupsList.data[0]}
+            />
           </div>
         </div>
       </GroupBody>

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -54,7 +54,7 @@
   --accent: hsl(224 15% 15% / 0.5);
   --accent-foreground: hsl(225, 35%, 90%);
   --destructive: hsl(0, 61%, 56%);
-  --destructive-background: hsl(0, 61%, 9%);
+  --destructive-background: hsl(3, 26%, 14%);
   --destructive-foreground: hsl(225, 35%, 90%);
   --border: hsl(224 5% 40%);
   --input: hsl(224 3.7% 15.9%);

--- a/todo.txt
+++ b/todo.txt
@@ -7,24 +7,11 @@
     [ ] 
 
 --ERROR HANDLING--
-    [ ] remove neverthrow hydration -> only on server
+    [ ] remove last artifacts of neverthrow
+    [ ] improve error handling reason on expense creation
 
 --UI--
-    [ ] dashboard
-        [ ] what to show here other than username
-    [ ] account page
-        [ ] update name
-        [ ] delete account
-    [ ] preferred group
-        [ ] ui indicator shown everywhere that preferred group is rendered
-        [ ] easy way to change this
-    [ ] allow landing page to be accessed regardless of auth state
-    [ ] move zero preload into loader
-        [ ] wrap entire _protected in another pathless folder
-            - _protected
-                - _protected-with-context
-            OR
-        [ ] move providers for zero/auth up a level
+    [ ] move zero instance to context to preload in loaders
 
 --INFRA--
     [ ] autodeploy from push (setup via sst)
@@ -40,12 +27,9 @@
     [ ] fix table sorts persist on group -> group navs
     [ ] expense member relation nullish, causes issues passing down as props
     [ ] unify focus/hover/border styles in sheet (need to unify input/button/select styles as such)
-    [x] sheet close ring style
-    [x] table left/right padding consistency/fix
     [ ] fix sidebar; push link from group label -> dedicated entry
 
 --DB--
-    [x] no transactions causes layout shift on new expense entries
     [ ] every field should have a createdAt
     [ ] UUID vs other id mechanism
     


### PR DESCRIPTION
when a member is removed or leaves, it creates a hole in the ui (paid by fields are left empty, and splits no longer sum to 100%)

this does the UI handling of this by showing an alert in the table row, blocks settlements from being invoked client side, and shows an alert in the bulk settle ui

it also adds a client/server mutator assertion that checks all to-be-settled expenses are in a valid split state