### PR TITLE
fix: simplify loading states + delay loading render

### DIFF
--- a/packages/web/src/components/loading.tsx
+++ b/packages/web/src/components/loading.tsx
@@ -1,14 +1,44 @@
 import { cn } from "@/lib/utils";
-import { PropsWithChildren } from "react";
+import { PropsWithChildren, useEffect, useRef, useState } from "react";
+
+type DelayedProps = PropsWithChildren<{ delay?: number }>;
+
+export function Delayed(props: DelayedProps) {
+  const [show, setShow] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    setShow(false);
+
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+
+    timeoutRef.current = setTimeout(() => {
+      setShow(true);
+    }, props.delay ?? 100);
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    };
+  }, [props.delay]);
+
+  if (!show) return null;
+  return <>{props.children}</>;
+}
 
 type LoadingProps = PropsWithChildren<{
+  useGuard?: boolean;
   omitBaseText?: boolean;
   whatIsLoading?: string;
   title?: string;
   className?: string;
 }>;
 
-export function Loading(props: LoadingProps) {
+export function LoadingInner(props: LoadingProps) {
   const title =
     props.title ??
     ["loading", props.whatIsLoading && ` ${props.whatIsLoading}`, "..."]
@@ -30,5 +60,15 @@ export function Loading(props: LoadingProps) {
           ))}
       </div>
     </div>
+  );
+}
+
+export function Loading(props: LoadingProps) {
+  if (!props.useGuard) return <LoadingInner {...props} />;
+
+  return (
+    <Delayed>
+      <LoadingInner {...props} />
+    </Delayed>
   );
 }

--- a/packages/web/src/pages/_protected/groups/$slug_id/layout.tsx
+++ b/packages/web/src/pages/_protected/groups/$slug_id/layout.tsx
@@ -11,7 +11,7 @@ import { useAuthentication } from "@/lib/authentication";
 import { Loading } from "@/components/loading";
 
 export const States = {
-  Loading: () => <Loading title="getting things settled..." />,
+  Loading: () => <Loading useGuard title="getting things settled..." />,
   NotFound: (props: { title: string }) => (
     <PrimaryHeading className="mx-auto py-12">
       Group "{props.title}" not found
@@ -133,8 +133,7 @@ function GroupLayout() {
         <PrimaryHeading>{title}</PrimaryHeading>
         <GroupNavigation {...params} />
       </PageHeaderRow>
-      {group.status === "loading" && <States.Loading />}
-      {group.status === "success" && <Outlet />}
+      <Outlet />
     </>
   );
 }

--- a/packages/web/src/pages/_protected/groups/$slug_id/page.tsx
+++ b/packages/web/src/pages/_protected/groups/$slug_id/page.tsx
@@ -79,7 +79,7 @@ function GroupRoute() {
   const mutate = useMutations();
 
   if (query.group.status === "loading") {
-    return null;
+    return <States.Loading />;
   }
 
   if (query.group.status === "not-found")

--- a/packages/web/src/pages/_protected/layout.tsx
+++ b/packages/web/src/pages/_protected/layout.tsx
@@ -175,7 +175,4 @@ export const Route = createFileRoute("/_protected")({
       ),
     ),
   }),
-  pendingComponent: () => (
-    <Loading className="min-h-screen" whatIsLoading="workspace" />
-  ),
 });


### PR DESCRIPTION
helper component that waits 150ms before rendering a loader, this way near instant promise resolution doesn't flash a loading indicator for no reason