### PR TITLE
fix: invites to live for 1 day

### DIFF
--- a/packages/core/src/modules/invite/entity.ts
+++ b/packages/core/src/modules/invite/entity.ts
@@ -48,10 +48,18 @@ export namespace invites {
     );
   }
 
-  export function create(invite: InviteInsert, tx?: Transaction) {
+  type CreateInvite = Omit<
+    InviteInsert,
+    "expiresAt" | "status" | "createdAt" | "acceptedAt"
+  >;
+
+  export function create(invite: CreateInvite, tx?: Transaction) {
     return pipe(
       Effect.tryPromise(() =>
-        (tx ?? db).insert(inviteTable).values(invite).returning(),
+        (tx ?? db)
+          .insert(inviteTable)
+          .values({ ...invite, expiresAt: utils.computeExpiry("day") })
+          .returning(),
       ),
       Effect.tap(Effect.logDebug),
       Effect.flatMap(

--- a/packages/web/src/server/invite.route.ts
+++ b/packages/web/src/server/invite.route.ts
@@ -153,10 +153,7 @@ export const createGroupInviteServerFn = createServerFn()
           yield* assertGroupHasInviteCapacity(data.groupId, tx);
           yield* assertGroupHasMemberCapacity(data.groupId, tx);
 
-          return yield* invites.create({
-            groupId: data.groupId,
-            expiresAt: invites.utils.computeExpiry("day"),
-          });
+          return yield* invites.create({ groupId: data.groupId });
         }),
       );
 

--- a/packages/web/src/server/invite.route.ts
+++ b/packages/web/src/server/invite.route.ts
@@ -155,7 +155,7 @@ export const createGroupInviteServerFn = createServerFn()
 
           return yield* invites.create({
             groupId: data.groupId,
-            expiresAt: invites.utils.computeExpiry(),
+            expiresAt: invites.utils.computeExpiry("day"),
           });
         }),
       );


### PR DESCRIPTION
updates expiration on invites and lifts responsibility on core logic around invite behavior into entity namespace