### PR TITLE
feat: ai model tweaks + minor infra tweaks

### DIFF
--- a/infra/domain.ts
+++ b/infra/domain.ts
@@ -61,7 +61,7 @@ export const getDomainConfig = (opts: MakeDomainConfigOpts) => {
 
   return {
     name,
-    dns: sst.cloudflare.dns(),
+    dns: sst.cloudflare.dns({ proxy: true }),
   };
 };
 

--- a/infra/sync.ts
+++ b/infra/sync.ts
@@ -38,6 +38,7 @@ const commonEnvironmentVariables = {
 
 export const Sync = new sst.aws.Service(`SyncViewSyncer`, {
   cluster: Cluster,
+  capacity: "spot",
   ...NonDevelopmentOnly(() => ({
     cpu: "1 vCPU",
     memory: "2 GB",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "db:reset": "pnpm dlx sst shell pnpm dlx tsx src/lib/drizzle/seed/reset.ts",
     "db:seed:e2e": "pnpm dlx sst shell pnpm dlx tsx src/lib/drizzle/seed/e2e/index.ts",
     "db:seed:expenses": "pnpm dlx sst shell pnpm dlx tsx src/lib/drizzle/seed/expenses.ts",
-    "ai:eval": "pnpm dlx sst shell braintrust eval ./src/ai/__tests__",
+    "ai:eval": "pnpm dlx sst shell braintrust eval ./src/lib/ai/__tests__/",
     "test": "pnpm dlx sst shell -- bun test",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@ai-sdk/google": "^1.2.10",
-    "@ai-sdk/groq": "^1.2.8",
+    "@ai-sdk/groq": "^1.2.9",
     "@ai-sdk/openai": "^1.3.9",
     "@ai-sdk/valibot": "^0.1.16",
     "@lmnr-ai/lmnr": "^0.5.0",

--- a/packages/core/src/lib/ai/__tests__/index.ts
+++ b/packages/core/src/lib/ai/__tests__/index.ts
@@ -7,8 +7,8 @@ import { data } from "./@nl.expense.dataset";
 
 type ModelDefintion = { fast: ModelKeys; quality: ModelKeys };
 export const MODELS: ModelDefintion = {
-  fast: "mini.llama-scout",
-  quality: "mini.gpt-4.1-mini",
+  fast: "pro.qwen3",
+  quality: "pro.qwen3",
 } as const;
 
 const PROJECT_BASE = "blank";
@@ -57,9 +57,9 @@ export function createExpenseEvalRunner(
     return await Eval(EXPENSE_EVAL_PROJECT, {
       data: dataset,
       async task(input) {
-        const res = await nl.expense.parse(input, {
-          fastModel: modelFast,
-          qualityModel: modelQuality,
+        const res = await nl.expense.parse({
+          description: input,
+          models: { fast: modelFast, quality: modelQuality },
         });
 
         if (res.isErr()) {

--- a/packages/core/src/lib/ai/models.ts
+++ b/packages/core/src/lib/ai/models.ts
@@ -17,9 +17,10 @@ const providers = {
 
 // would like to use groq bc of inference speed, but gpt 4o/4.1 are performing vastly more consistently for now
 
+// good, fast, cheap defaults when multi-modal is not needed
 export const defaults = {
-  quality: "pro.gpt-4.1",
-  fast: "mini.gpt-4.1-mini",
+  quality: "pro.qwen3",
+  fast: "pro.qwen3",
 } satisfies Record<string, ModelKeys>;
 
 export type ModelKeys = keyof typeof models;
@@ -32,9 +33,6 @@ export const models = {
   "mini.gpt-4.1-mini": () => providers.openai("gpt-4.1-mini"),
   "mini.gpt-4.1-nano": () => providers.openai("gpt-4.1-nano"),
 
-  // qwen
-  "reasoning.qwen-qwq": () => providers.groq("qwen-qwq-32b"),
-
   // llama
   "mini.llama-scout": () =>
     providers.groq("meta-llama/llama-4-scout-17b-16e-instruct"),
@@ -43,9 +41,11 @@ export const models = {
   "pro.llama-maverick": () =>
     providers.groq("meta-llama/llama-4-maverick-17b-128e-instruct"),
 
-  // deepseek
+  // groq other
   "reasoning.deepseek-r1-llama": () =>
     providers.groq("deepseek-r1-distill-llama-70b"),
+  "pro.qwen3": () => providers.groq("qwen/qwen3-32b"),
+  "pro.kimi-k2": () => providers.groq("moonshotai/kimi-k2-instruct"),
 } as const;
 
 export const create = (model?: ModelKeys) =>

--- a/packages/core/src/lib/ai/nl.ts
+++ b/packages/core/src/lib/ai/nl.ts
@@ -6,6 +6,7 @@ import { ResultAsync, err, ok } from "neverthrow";
 import { ExpenseInsert } from "../../modules/expense/schema";
 import { ParticipantInsert } from "../../modules/participant/schema";
 import { fromParsed } from "../_legacy/neverthrow";
+import { optional } from "../utils";
 
 const toDecimalSplit = (split: readonly [number, number]) =>
   split[0] / split[1];
@@ -45,6 +46,7 @@ export namespace nl {
     "id",
     "createdAt",
     "date",
+    "status",
   ]);
 
   const memberSchemaBase = v.object({
@@ -141,18 +143,20 @@ export namespace nl {
         models[options.models?.quality ?? defaults.quality]();
       const fastModel = models[options.models?.fast ?? defaults.fast]();
 
+      console.log("[quality] ", qualityModel, "[fast] ", fastModel);
+
       // TODO: split the context into two parts
       const fastLLMParser = createSafeGenerateObject({
         schema: valibotSchema(this.config.schema.llm),
         system: this.config.grounding,
         model: fastModel,
-        images: options.images ?? [],
+        ...optional({ images: options.images }),
       });
       const qualityLLMParser = createSafeGenerateObject({
         schema: valibotSchema(this.config.schema.llm),
         system: this.config.grounding,
         model: qualityModel,
-        images: options.images ?? [],
+        ...optional({ images: options.images }),
       });
 
       return ResultAsync.combine([

--- a/packages/core/src/lib/ai/nl.ts
+++ b/packages/core/src/lib/ai/nl.ts
@@ -143,8 +143,6 @@ export namespace nl {
         models[options.models?.quality ?? defaults.quality]();
       const fastModel = models[options.models?.fast ?? defaults.fast]();
 
-      console.log("[quality] ", qualityModel, "[fast] ", fastModel);
-
       // TODO: split the context into two parts
       const fastLLMParser = createSafeGenerateObject({
         schema: valibotSchema(this.config.schema.llm),

--- a/packages/web/src/server/expense.route.ts
+++ b/packages/web/src/server/expense.route.ts
@@ -49,6 +49,7 @@ export const createFromDescriptionServerFn = createServerFn({
         groupId: ctx.data.groupId,
         description: ctx.data.description,
         images: ctx.data.images as ImageDataUrl[],
+        parser: user.plan,
       });
 
       return expense;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,7 +130,7 @@ importers:
         specifier: ^1.2.10
         version: 1.2.22(zod@3.25.71)
       '@ai-sdk/groq':
-        specifier: ^1.2.8
+        specifier: ^1.2.9
         version: 1.2.9(zod@3.25.71)
       '@ai-sdk/openai':
         specifier: ^1.3.9
@@ -154,14 +154,14 @@ importers:
         specifier: ^0.0.197
         version: 0.0.197(openai@4.104.0(ws@8.18.3)(zod@3.25.71))(react@19.1.1)(solid-js@1.9.7)(sswr@2.2.0(svelte@5.35.1))(svelte@5.35.1)(vue@3.5.17(typescript@5.8.3))(zod@3.25.71)
       drizzle-orm:
-        specifier: ^0.39.3
-        version: 0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7)
+        specifier: ^0.44.4
+        version: 0.44.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7)
       drizzle-seed:
         specifier: ^0.3.1
-        version: 0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))
+        version: 0.3.1(drizzle-orm@0.44.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))
       drizzle-valibot:
         specifier: ^0.4.1
-        version: 0.4.2(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))(valibot@1.1.0(typescript@5.8.3))
+        version: 0.4.2(drizzle-orm@0.44.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))(valibot@1.1.0(typescript@5.8.3))
     devDependencies:
       '@types/ws':
         specifier: ^8.18.1
@@ -243,7 +243,7 @@ importers:
         version: 5.83.0
       '@tanstack/react-form':
         specifier: ^1.15.1
-        version: 1.15.1(@tanstack/react-start@1.130.9(@tanstack/react-router@1.130.9(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(aws4fetch@1.0.20)(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(xml2js@0.6.2))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 1.15.1(@tanstack/react-start@1.130.9(@tanstack/react-router@1.130.9(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(aws4fetch@1.0.20)(drizzle-orm@0.44.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(xml2js@0.6.2))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tanstack/react-query':
         specifier: ^5.83.0
         version: 5.83.0(react@19.1.1)
@@ -261,7 +261,7 @@ importers:
         version: 1.130.9(@tanstack/react-query@5.83.0(react@19.1.1))(@tanstack/react-router@1.130.9(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@tanstack/router-core@1.130.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tanstack/react-start':
         specifier: ^1.130.9
-        version: 1.130.9(@tanstack/react-router@1.130.9(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(aws4fetch@1.0.20)(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(xml2js@0.6.2)
+        version: 1.130.9(@tanstack/react-router@1.130.9(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(aws4fetch@1.0.20)(drizzle-orm@0.44.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(xml2js@0.6.2)
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -4600,8 +4600,8 @@ packages:
     resolution: {integrity: sha512-tCPWVZWZqWVx2XUsVpJRnH9Mx0ClVOf5YUHerZ5so1OKSlqww4zy1R5ksEdGRcO3tM3zj0PYN6V48TbQCL1RfA==}
     hasBin: true
 
-  drizzle-orm@0.39.3:
-    resolution: {integrity: sha512-EZ8ZpYvDIvKU9C56JYLOmUskazhad+uXZCTCRN4OnRMsL+xAJ05dv1eCpAG5xzhsm1hqiuC5kAZUCS924u2DTw==}
+  drizzle-orm@0.44.4:
+    resolution: {integrity: sha512-ZyzKFpTC/Ut3fIqc2c0dPZ6nhchQXriTsqTNs4ayRgl6sZcFlMs9QZKPSHXK4bdOf41GHGWf+FrpcDDYwW+W6Q==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=4'
@@ -4611,17 +4611,19 @@ packages:
       '@neondatabase/serverless': '>=0.10.0'
       '@op-engineering/op-sqlite': '>=2'
       '@opentelemetry/api': ^1.4.1
-      '@planetscale/database': '>=1'
+      '@planetscale/database': '>=1.13'
       '@prisma/client': '*'
       '@tidbcloud/serverless': '*'
       '@types/better-sqlite3': '*'
       '@types/pg': '*'
       '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
       '@vercel/postgres': '>=0.8.0'
       '@xata.io/client': '*'
       better-sqlite3: '>=7'
       bun-types: '*'
       expo-sqlite: '>=14.0.0'
+      gel: '>=2'
       knex: '*'
       kysely: '*'
       mysql2: '>=2'
@@ -4659,6 +4661,8 @@ packages:
         optional: true
       '@types/sql.js':
         optional: true
+      '@upstash/redis':
+        optional: true
       '@vercel/postgres':
         optional: true
       '@xata.io/client':
@@ -4668,6 +4672,8 @@ packages:
       bun-types:
         optional: true
       expo-sqlite:
+        optional: true
+      gel:
         optional: true
       knex:
         optional: true
@@ -11154,7 +11160,7 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.83.0
 
-  '@tanstack/react-form@1.15.1(@tanstack/react-start@1.130.9(@tanstack/react-router@1.130.9(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(aws4fetch@1.0.20)(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(xml2js@0.6.2))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@tanstack/react-form@1.15.1(@tanstack/react-start@1.130.9(@tanstack/react-router@1.130.9(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(aws4fetch@1.0.20)(drizzle-orm@0.44.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(xml2js@0.6.2))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@tanstack/form-core': 1.15.1
       '@tanstack/react-store': 0.7.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -11162,7 +11168,7 @@ snapshots:
       devalue: 5.1.1
       react: 19.1.1
     optionalDependencies:
-      '@tanstack/react-start': 1.130.9(@tanstack/react-router@1.130.9(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(aws4fetch@1.0.20)(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(xml2js@0.6.2)
+      '@tanstack/react-start': 1.130.9(@tanstack/react-router@1.130.9(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(aws4fetch@1.0.20)(drizzle-orm@0.44.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(xml2js@0.6.2)
     transitivePeerDependencies:
       - react-dom
 
@@ -11219,9 +11225,9 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  '@tanstack/react-start-plugin@1.130.9(@tanstack/react-router@1.130.9(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(aws4fetch@1.0.20)(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(xml2js@0.6.2)':
+  '@tanstack/react-start-plugin@1.130.9(@tanstack/react-router@1.130.9(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(aws4fetch@1.0.20)(drizzle-orm@0.44.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(xml2js@0.6.2)':
     dependencies:
-      '@tanstack/start-plugin-core': 1.130.9(@tanstack/react-router@1.130.9(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(aws4fetch@1.0.20)(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(xml2js@0.6.2)
+      '@tanstack/start-plugin-core': 1.130.9(@tanstack/react-router@1.130.9(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(aws4fetch@1.0.20)(drizzle-orm@0.44.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(xml2js@0.6.2)
       '@vitejs/plugin-react': 4.7.0(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
       pathe: 2.0.3
       vite: 7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
@@ -11270,10 +11276,10 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
-  '@tanstack/react-start@1.130.9(@tanstack/react-router@1.130.9(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(aws4fetch@1.0.20)(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(xml2js@0.6.2)':
+  '@tanstack/react-start@1.130.9(@tanstack/react-router@1.130.9(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(aws4fetch@1.0.20)(drizzle-orm@0.44.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(xml2js@0.6.2)':
     dependencies:
       '@tanstack/react-start-client': 1.130.9(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@tanstack/react-start-plugin': 1.130.9(@tanstack/react-router@1.130.9(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(aws4fetch@1.0.20)(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(xml2js@0.6.2)
+      '@tanstack/react-start-plugin': 1.130.9(@tanstack/react-router@1.130.9(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)))(aws4fetch@1.0.20)(drizzle-orm@0.44.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(xml2js@0.6.2)
       '@tanstack/react-start-server': 1.130.9(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tanstack/start-server-functions-client': 1.130.9(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
       '@tanstack/start-server-functions-server': 1.129.7(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
@@ -11416,7 +11422,7 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  '@tanstack/start-plugin-core@1.130.9(@tanstack/react-router@1.130.9(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(aws4fetch@1.0.20)(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(xml2js@0.6.2)':
+  '@tanstack/start-plugin-core@1.130.9(@tanstack/react-router@1.130.9(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(aws4fetch@1.0.20)(drizzle-orm@0.44.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))(vite@7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(xml2js@0.6.2)':
     dependencies:
       '@babel/code-frame': 7.26.2
       '@babel/core': 7.28.0
@@ -11432,7 +11438,7 @@ snapshots:
       babel-dead-code-elimination: 1.0.10
       cheerio: 1.1.0
       h3: 1.13.0
-      nitropack: 2.11.13(aws4fetch@1.0.20)(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))(xml2js@0.6.2)
+      nitropack: 2.11.13(aws4fetch@1.0.20)(drizzle-orm@0.44.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))(xml2js@0.6.2)
       pathe: 2.0.3
       ufo: 1.6.1
       vite: 7.0.6(@types/node@22.16.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
@@ -12765,9 +12771,9 @@ snapshots:
 
   dateformat@4.6.3: {}
 
-  db0@0.3.2(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7)):
+  db0@0.3.2(drizzle-orm@0.44.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7)):
     optionalDependencies:
-      drizzle-orm: 0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7)
+      drizzle-orm: 0.44.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7)
 
   debug@3.2.7:
     dependencies:
@@ -12924,7 +12930,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7):
+  drizzle-orm@0.44.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7):
     optionalDependencies:
       '@neondatabase/serverless': 0.10.4
       '@opentelemetry/api': 1.9.0
@@ -12932,15 +12938,15 @@ snapshots:
       bun-types: 1.2.17
       postgres: 3.4.7
 
-  drizzle-seed@0.3.1(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7)):
+  drizzle-seed@0.3.1(drizzle-orm@0.44.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7)):
     dependencies:
       pure-rand: 6.1.0
     optionalDependencies:
-      drizzle-orm: 0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7)
+      drizzle-orm: 0.44.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7)
 
-  drizzle-valibot@0.4.2(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))(valibot@1.1.0(typescript@5.8.3)):
+  drizzle-valibot@0.4.2(drizzle-orm@0.44.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))(valibot@1.1.0(typescript@5.8.3)):
     dependencies:
-      drizzle-orm: 0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7)
+      drizzle-orm: 0.44.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7)
       valibot: 1.1.0(typescript@5.8.3)
 
   dunder-proto@1.0.1:
@@ -14549,7 +14555,7 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
-  nitropack@2.11.13(aws4fetch@1.0.20)(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))(xml2js@0.6.2):
+  nitropack@2.11.13(aws4fetch@1.0.20)(drizzle-orm@0.44.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))(xml2js@0.6.2):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.0
       '@netlify/functions': 3.1.10(rollup@4.44.2)
@@ -14571,7 +14577,7 @@ snapshots:
       cookie-es: 2.0.0
       croner: 9.1.0
       crossws: 0.3.5
-      db0: 0.3.2(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))
+      db0: 0.3.2(drizzle-orm@0.44.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))
       defu: 6.1.4
       destr: 2.0.5
       dot-prop: 9.0.0
@@ -14617,7 +14623,7 @@ snapshots:
       unenv: 2.0.0-rc.18
       unimport: 5.1.0
       unplugin-utils: 0.2.4
-      unstorage: 1.16.0(aws4fetch@1.0.20)(db0@0.3.2(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7)))(ioredis@5.6.1)
+      unstorage: 1.16.0(aws4fetch@1.0.20)(db0@0.3.2(drizzle-orm@0.44.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7)))(ioredis@5.6.1)
       untyped: 2.0.0
       unwasm: 0.3.9
       youch: 4.1.0-beta.8
@@ -16167,7 +16173,7 @@ snapshots:
       picomatch: 4.0.2
       webpack-virtual-modules: 0.6.2
 
-  unstorage@1.16.0(aws4fetch@1.0.20)(db0@0.3.2(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7)))(ioredis@5.6.1):
+  unstorage@1.16.0(aws4fetch@1.0.20)(db0@0.3.2(drizzle-orm@0.44.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7)))(ioredis@5.6.1):
     dependencies:
       anymatch: 3.1.3
       chokidar: 4.0.3
@@ -16179,7 +16185,7 @@ snapshots:
       ufo: 1.6.1
     optionalDependencies:
       aws4fetch: 1.0.20
-      db0: 0.3.2(drizzle-orm@0.39.3(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))
+      db0: 0.3.2(drizzle-orm@0.44.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(bun-types@1.2.17)(postgres@3.4.7))
       ioredis: 5.6.1
 
   untun@0.1.3:


### PR DESCRIPTION
update ai setup so:
- qwen 3 default model - appears to perform sufficiently for the parsing task based on a bit of eval
- "pro" plan (temporary for now)
  - expense parsing => 4.1 mini
  - members parsing => 4.1
  
also moves to spot instance for zero + cloudflare proxy for dns