### PR TITLE
feat: handle no default group present

### DIFF
--- a/packages/web/src/components/navigation.tsx
+++ b/packages/web/src/components/navigation.tsx
@@ -45,6 +45,11 @@ type SidebarMenuItemChunkProps = PropsWithClassname<{
     | {
         label: string;
       };
+  disabled?:
+    | false
+    | {
+        message: string;
+      };
 }>;
 
 function SidebarMenuItemChunk(props: SidebarMenuItemChunkProps) {
@@ -71,6 +76,10 @@ function SidebarMenuItemChunk(props: SidebarMenuItemChunkProps) {
         >
           {props.item.type === "link" ? (
             <Link
+              aria-disabled={
+                (props.disabled && !!props.disabled.message) ?? false
+              }
+              title={props.disabled ? props.disabled.message : undefined}
               activeOptions={{
                 exact: false,
                 includeSearch: props.matchOnSearch ?? false,
@@ -103,17 +112,28 @@ function SidebarMenuItemChunk(props: SidebarMenuItemChunkProps) {
 
 type QuickActionsProps = {
   position: number;
+  userHasGroups: boolean;
 };
 
 function QuickActions(props: QuickActionsProps) {
   const quickActions: (SidebarItemChunk & {
     isSearchRelatedAction?: boolean;
+    disabled?:
+      | false
+      | {
+          message: string;
+        };
   })[] = [
     { type: "link", title: "Home", opts: { to: "/" } },
     {
       type: "link",
       title: "New Expense",
       isSearchRelatedAction: true,
+      disabled: props.userHasGroups
+        ? false
+        : {
+            message: "asdfas",
+          },
       opts: {
         to: ".",
         search: (prev) => ({
@@ -132,6 +152,7 @@ function QuickActions(props: QuickActionsProps) {
           item={item}
           index={props.position + index}
           matchOnSearch={item.isSearchRelatedAction ?? false}
+          disabled={item.disabled ?? false}
         />
       ))}
     </>
@@ -222,7 +243,10 @@ export function GlobalSidebar(props: SideNavigationProps) {
       <SidebarContent className="overflow-x-hidden">
         <SidebarGroup className="group-data-[collapsible=icon]:hidden">
           <SidebarMenu>
-            <QuickActions position={0} />
+            <QuickActions
+              userHasGroups={groups.status === "success"}
+              position={0}
+            />
           </SidebarMenu>
         </SidebarGroup>
         <SidebarGroup className="group-data-[collapsible=icon]:hidden">

--- a/packages/web/src/components/ui/dialog.tsx
+++ b/packages/web/src/components/ui/dialog.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { XIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { useRef } from "react";
@@ -59,10 +58,10 @@ function DialogContent({
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
       <DialogPrimitive.Content
-        onOpenAutoFocus={(e) => {
+        onOpenAutoFocus={(_e) => {
           previous.current = document.activeElement as HTMLElement;
         }}
-        onCloseAutoFocus={(e) => {
+        onCloseAutoFocus={(_e) => {
           if (document.activeElement !== document.body) return;
 
           previous.current?.focus();

--- a/packages/web/src/pages/_protected/@command-bar.dialog.tsx
+++ b/packages/web/src/pages/_protected/@command-bar.dialog.tsx
@@ -12,8 +12,8 @@ import { Link, LinkOptions, useNavigate } from "@tanstack/react-router";
 import { useAuthentication } from "@/lib/authentication";
 import * as v from "valibot";
 import { createStackableSearchRoute } from "@/lib/search-route";
-import { SearchRoute as CreateExpenseRoute } from "./@create-expense.dialog";
 import { useGroupListByUserId } from "./@data/groups";
+import CreateExpenseRoute from "./@create-expense/route";
 
 const KEY = "action";
 const ENTRY = "command" as const;
@@ -75,7 +75,7 @@ export function GlobalCommandBar() {
         opts,
         go: () => {
           route.close();
-          createExpenseRoute.open(true);
+          createExpenseRoute.open({ solo: true });
         },
       };
     }),

--- a/packages/web/src/pages/_protected/@create-expense/route.tsx
+++ b/packages/web/src/pages/_protected/@create-expense/route.tsx
@@ -1,0 +1,19 @@
+import { createStackableSearchRoute } from "@/lib/search-route";
+import * as v from "valibot";
+
+const constants = {
+  key: "action",
+  entry: "new-expense",
+};
+
+export type CreateExpenseSearchRouteSchema = v.InferOutput<
+  typeof CreateExpenseSearchRouteSchema
+>;
+
+export const CreateExpenseSearchRouteSchema = v.object({
+  [constants.key]: v.literal(constants.entry),
+});
+
+const SearchRoute = createStackableSearchRoute(constants.key, constants.entry);
+
+export default SearchRoute;

--- a/packages/web/src/pages/_protected/@create-group/dialog.tsx
+++ b/packages/web/src/pages/_protected/@create-group/dialog.tsx
@@ -4,17 +4,20 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import * as v from "valibot";
+// import SearchRoute from "./route";
 import { ok, Result, ResultAsync } from "neverthrow";
-import { ValidationErrorLegacy } from "@blank/core/lib/effect/index";
-import { useState } from "react";
-import { slugify } from "@blank/core/lib/utils/index";
-import { Label } from "@/components/ui/label";
-import { useCreateGroup } from "../@data/groups";
-import { createStackableSearchRoute } from "@/lib/search-route";
 import { fromParsed } from "@blank/core/lib/_legacy/neverthrow";
+import { ValidationErrorLegacy } from "@blank/core/lib/effect/index";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { slugify } from "@blank/core/lib/utils/index";
+import { useCreateGroup } from "../@data/groups";
+import { useState } from "react";
+import { useSearch } from "@tanstack/react-router";
+import { templates } from "./templates";
+import SearchRoute from "./route";
 
 const invalidCharactersMessage =
   "Title must only contain letters, numbers, and spaces";
@@ -39,22 +42,19 @@ const schemas = {
   ),
 };
 
-const ENTRY = "new-group" as const;
-export const SearchRoute = createStackableSearchRoute("action", ENTRY);
-export type SearchRouteSchema = v.InferOutput<typeof SearchRouteSchema>;
-export const SearchRouteSchema = v.object({
-  action: v.literal(ENTRY),
-});
-
-export type CreateGroupDialogProps = {
-  searchValue: string[];
-  onSubmit: (title: string, description: string) => Promise<void>;
-};
-
 export function CreateGroupDialog() {
   const createGroup = useCreateGroup();
   const formKeys = { title: "group-title", description: "group-description" };
   const route = SearchRoute.useSearchRoute();
+
+  const templateKey = useSearch({
+    strict: false,
+    select: (state) => {
+      return state.template;
+    },
+  });
+
+  const template = new Map(Object.entries(templates)).get(templateKey ?? "");
 
   const [error, setError] = useState<string | null>(null);
 
@@ -90,7 +90,7 @@ export function CreateGroupDialog() {
     <Dialog
       open={route.view() === "open"}
       onOpenChange={(bool) => {
-        (bool ? route.open : route.close)();
+        (bool ? route.open : route.close)({});
         if (!bool) setError(null);
       }}
     >
@@ -124,6 +124,7 @@ export function CreateGroupDialog() {
               name={formKeys.title}
               className="bg-transparent border-0 p-0 focus-visible:ring-0 placeholder:text-muted-foreground/60 flex-1"
               placeholder="enter a group name"
+              defaultValue={template?.title}
             />
           </div>
           <div className="px-3 py-2 w-full bg-popover space-y-0.5 col-span-full">
@@ -141,6 +142,7 @@ export function CreateGroupDialog() {
               name={formKeys.description}
               className="bg-transparent border-0 p-0 focus-visible:ring-0 placeholder:text-muted-foreground/60 flex-1"
               placeholder="enter a group description"
+              defaultValue={template?.description}
             />
           </div>
           <Button

--- a/packages/web/src/pages/_protected/@create-group/dialog.tsx
+++ b/packages/web/src/pages/_protected/@create-group/dialog.tsx
@@ -90,7 +90,7 @@ export function CreateGroupDialog() {
     <Dialog
       open={route.view() === "open"}
       onOpenChange={(bool) => {
-        (bool ? route.open : route.close)({});
+        (bool ? route.open : route.close)();
         if (!bool) setError(null);
       }}
     >

--- a/packages/web/src/pages/_protected/@create-group/route.tsx
+++ b/packages/web/src/pages/_protected/@create-group/route.tsx
@@ -1,0 +1,27 @@
+import { createStackableSearchRoute } from "@/lib/search-route";
+import * as v from "valibot";
+import { templates } from "./templates";
+
+const constants = {
+  key: "action",
+  entry: "new-group",
+} as const;
+
+const siblings = {
+  template: v.picklist(Object.values(templates).map((v) => v.title)),
+};
+
+export type CreateGroupSearchRouteSchema = v.InferOutput<
+  typeof CreateGroupSearchRouteSchema
+>;
+
+export const CreateGroupSearchRouteSchema = v.object({
+  [constants.key]: v.literal(constants.entry),
+  ...siblings,
+});
+
+const SearchRoute = createStackableSearchRoute(constants.key, constants.entry, {
+  siblingKeys: Object.keys(siblings),
+});
+
+export default SearchRoute;

--- a/packages/web/src/pages/_protected/@create-group/templates.ts
+++ b/packages/web/src/pages/_protected/@create-group/templates.ts
@@ -1,0 +1,22 @@
+export const templates = {
+  family: {
+    title: "family",
+    description: "share day-to-day costs",
+  },
+  roommates: {
+    title: "roommates",
+    description: "split rent & utilities",
+  },
+  trip: {
+    title: "trip",
+    description: "plan & share travel costs",
+  },
+  couple: {
+    title: "couple",
+    description: "track shared expenses",
+  },
+  event: {
+    title: "event",
+    description: "organize one-off expenses",
+  },
+} as const;

--- a/packages/web/src/pages/_protected/@data/groups.ts
+++ b/packages/web/src/pages/_protected/@data/groups.ts
@@ -59,7 +59,6 @@ export function useCreateGroup() {
       id,
       description,
       title,
-      userId: auth.user.id,
       nickname: auth.user.name,
     }).client;
   };

--- a/packages/web/src/pages/_protected/groups/$slug_id/@expense/route.tsx
+++ b/packages/web/src/pages/_protected/groups/$slug_id/@expense/route.tsx
@@ -1,0 +1,14 @@
+import { createSearchRoute } from "@/lib/search-route";
+import * as v from "valibot";
+
+export const constants = {
+  key: "expense",
+} as const;
+
+export const ExpenseSheetSearchRouteSchema = v.object({
+  [constants.key]: v.optional(v.string()),
+});
+
+const SearchRoute = createSearchRoute(constants.key);
+
+export default SearchRoute;

--- a/packages/web/src/pages/_protected/groups/$slug_id/@expense/sheet.tsx
+++ b/packages/web/src/pages/_protected/groups/$slug_id/@expense/sheet.tsx
@@ -1,40 +1,37 @@
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetBody,
-  SheetFooter,
-} from "@/components/ui/sheet";
-import * as v from "valibot";
-import { ExpenseWithParticipants } from "./page";
-import { createSearchRoute } from "@/lib/search-route";
-import { useWithConfirmation } from "@/components/with-confirmation-dialog";
-import { FieldsErrors, useAppForm } from "@/components/form";
-import { fraction, prevented, timestampToDate } from "@/lib/utils";
-import {
-  DeleteOptions as DeleteExpenseOptions,
-  UpdateOptions as UpdateExpenseOptions,
-} from "@/lib/client-mutators/expense-mutators";
 import { PropsWithChildren } from "react";
-import { Separator } from "@/components/ui/separator";
+import { ExpenseWithParticipants } from "../page";
+import { useAuthentication } from "@/lib/authentication";
 import {
   getPayerFromParticipants,
   ParticipantWithMember,
 } from "@/lib/participants";
+import { useWithConfirmation } from "@/components/with-confirmation-dialog";
 import { withToast } from "@/lib/toast";
-import { Participant } from "@blank/zero";
-import { useDeleteOneExpense, useUpdateExpense } from "../../@data/expenses";
-import { optional } from "@blank/core/lib/utils/index";
-import { ChevronRight } from "lucide-react";
-import { useAuthentication } from "@/lib/authentication";
+import {
+  DeleteOptions as DeleteExpenseOptions,
+  UpdateOptions as UpdateExpenseOptions,
+} from "@/lib/client-mutators/expense-mutators";
 import { DialogDescription } from "@/components/ui/dialog";
-
-export const KEY = "expense" as const;
-export const SearchRouteSchema = v.object({
-  [KEY]: v.optional(v.string()),
-});
-export const SearchRoute = createSearchRoute(KEY);
+import { ChevronRight } from "lucide-react";
+import { fraction, prevented, timestampToDate } from "@/lib/utils";
+import {
+  useDeleteOneExpense,
+  useUpdateExpense,
+} from "@/pages/_protected/@data/expenses";
+import * as v from "valibot";
+import { FieldsErrors, useAppForm } from "@/components/form";
+import { Participant } from "@blank/zero";
+import { optional } from "@blank/core/lib/utils/index";
+import {
+  Sheet,
+  SheetBody,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Separator } from "@/components/ui/separator";
+import ExpenseSheetSearchRoute from "./route";
 
 function useConfirmDeleteExpense(
   expenseId: string,
@@ -283,7 +280,7 @@ type ExpenseSheetProps = PropsWithChildren<{
 
 export function ExpenseSheet(props: ExpenseSheetProps) {
   const auth = useAuthentication();
-  const route = SearchRoute.useSearchRoute();
+  const route = ExpenseSheetSearchRoute.useSearchRoute();
   const active = props.expense;
 
   const payer = getPayerFromParticipants(active.participants);

--- a/packages/web/src/pages/_protected/groups/$slug_id/@settle/dialog.tsx
+++ b/packages/web/src/pages/_protected/groups/$slug_id/@settle/dialog.tsx
@@ -1,30 +1,8 @@
 import { useState } from "react";
+import { ExpenseWithParticipants } from "../page";
 import { useValidateDialogProgression } from "./validate-progression";
-import * as v from "valibot";
 import { Step1 } from "./step-1";
 import { Step2 } from "./step-2";
-import { createStackableSearchRoute } from "@/lib/search-route";
-import { ExpenseWithParticipants } from "../page";
-
-export type Step = `${typeof PREFIX}-${number}`;
-
-export const KEY = "settle" as const;
-
-export const PREFIX = "step" as const;
-export const STEP_ONE: Step = "step-1" as const;
-export const STEP_TWO: Step = "step-2" as const;
-
-export const SearchRouteStep1 = createStackableSearchRoute(KEY, STEP_ONE);
-export const SearchRouteStep2 = createStackableSearchRoute(KEY, STEP_TWO);
-
-export const SearchRouteSchema = v.object({
-  [KEY]: v.optional(
-    v.fallback(
-      v.array(v.union([v.literal<Step>(STEP_ONE), v.literal<Step>(STEP_TWO)])),
-      [STEP_TWO],
-    ),
-  ),
-});
 
 type SettleExpensesDialogProps = {
   active: ExpenseWithParticipants[];

--- a/packages/web/src/pages/_protected/groups/$slug_id/@settle/route.tsx
+++ b/packages/web/src/pages/_protected/groups/$slug_id/@settle/route.tsx
@@ -1,0 +1,36 @@
+import { createStackableSearchRoute } from "@/lib/search-route";
+import * as v from "valibot";
+
+export type Step = `${typeof constants.prefix}-${number}`;
+
+export const constants = {
+  key: "settle",
+  prefix: "step",
+  steps: {
+    one: "step-1",
+    two: "step-2",
+  },
+} as const;
+
+export const SearchRouteStep1 = createStackableSearchRoute(
+  constants.key,
+  constants.steps.one,
+);
+export const SearchRouteStep2 = createStackableSearchRoute(
+  constants.key,
+  constants.steps.two,
+);
+
+export const SearchRouteSchema = v.object({
+  [constants.key]: v.optional(
+    v.fallback(
+      v.array(
+        v.union([
+          v.literal<Step>(constants.steps.one),
+          v.literal<Step>(constants.steps.two),
+        ]),
+      ),
+      [constants.steps.two],
+    ),
+  ),
+});

--- a/packages/web/src/pages/_protected/groups/$slug_id/@settle/step-1.tsx
+++ b/packages/web/src/pages/_protected/groups/$slug_id/@settle/step-1.tsx
@@ -11,7 +11,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 
-import { SearchRouteStep1 } from ".";
+import { SearchRouteStep1 } from "./route";
 import { Route } from "../page";
 import { cn } from "@/lib/utils";
 import { CollapsibleNotification } from "@/components/collapsible-notification";

--- a/packages/web/src/pages/_protected/groups/$slug_id/@settle/step-2.tsx
+++ b/packages/web/src/pages/_protected/groups/$slug_id/@settle/step-2.tsx
@@ -11,7 +11,7 @@ import {
   DialogDescription,
 } from "@/components/ui/dialog";
 import { PropsWithChildren } from "react";
-import { SearchRouteStep2 } from ".";
+import { SearchRouteStep2 } from "./route";
 import { ExpenseWithParticipants, Route } from "../page";
 import { calculateSettlements, createBalanceMap } from "@/lib/balances";
 import { useGroupById } from "@/pages/_protected/@data/groups";

--- a/packages/web/src/pages/_protected/groups/$slug_id/@settle/validate-progression.tsx
+++ b/packages/web/src/pages/_protected/groups/$slug_id/@settle/validate-progression.tsx
@@ -1,6 +1,6 @@
 import { Route } from "../page";
 import * as v from "valibot";
-import { KEY, PREFIX, SearchRouteStep1, SearchRouteStep2 } from ".";
+import { constants, SearchRouteStep1, SearchRouteStep2 } from "./route";
 
 export function useValidateDialogProgression(activeExpenseCount: number) {
   const routes = [
@@ -10,7 +10,7 @@ export function useValidateDialogProgression(activeExpenseCount: number) {
   const navigate = Route.useNavigate();
   const search = Route.useSearch({
     select(state) {
-      return state[KEY];
+      return state[constants.key];
     },
   });
 
@@ -22,7 +22,7 @@ export function useValidateDialogProgression(activeExpenseCount: number) {
       // parses the progression of steps, validates they're correctly in order, returns the current step
       v.pipe(
         v.array(v.string()),
-        v.everyItem((s) => s.startsWith(PREFIX)),
+        v.everyItem((s) => s.startsWith(constants.prefix)),
         v.transform((value) => value.map((s) => s.split("-").at(1))),
         v.nonNullable(v.array(v.string())),
         v.transform((value) => value.map((s) => parseInt(s))),
@@ -48,7 +48,7 @@ export function useValidateDialogProgression(activeExpenseCount: number) {
       to: ".",
       search: (previous) => ({
         ...previous,
-        [KEY]: undefined,
+        [constants.key]: undefined,
       }),
     });
   };

--- a/packages/web/src/pages/_protected/groups/$slug_id/page.tsx
+++ b/packages/web/src/pages/_protected/groups/$slug_id/page.tsx
@@ -159,8 +159,8 @@ export const Route = createFileRoute("/_protected/groups/$slug_id/")({
     ],
   },
   validateSearch: v.object({
-    ...ExpenseSheetSearchRouteSchema.entries, // good
-    ...SettleExpensesSearchRouteSchema.entries, // good
+    ...ExpenseSheetSearchRouteSchema.entries,
+    ...SettleExpensesSearchRouteSchema.entries,
     ...QuerySchema.entries,
     ...StatusSchema.entries,
     ...FiltersSchema.entries,

--- a/packages/web/src/pages/_protected/groups/$slug_id/page.tsx
+++ b/packages/web/src/pages/_protected/groups/$slug_id/page.tsx
@@ -2,16 +2,6 @@ import { createFileRoute } from "@tanstack/react-router";
 import { SubHeading } from "@/components/prose";
 import { GroupBody, States } from "./layout";
 import { DataTable } from "./@dashboard/expense-table";
-import {
-  ExpenseSheet,
-  SearchRoute as ExpenseSheetSearchRoute,
-  SearchRouteSchema as ExpenseSheetSearchRouteSchema,
-} from "./@expense.sheet";
-import {
-  SettleExpensesDialog,
-  SearchRouteStep1 as SettleExpensesSearchRoute,
-  SearchRouteSchema as SettleExpensesSearchRouteSchema,
-} from "./@settle-dialog";
 import { Expense, Member, Expense as ZeroExpense } from "@blank/zero";
 import { ParticipantWithMember } from "@/lib/participants";
 import * as v from "valibot";
@@ -33,6 +23,15 @@ import { QuerySchema, useQueryFromSearch } from "./@dashboard/table-query";
 import { StatusSchema, useStatusFromSearch } from "./@dashboard/table-status";
 import { createBalanceMap } from "@/lib/balances";
 import { slugify } from "@blank/core/lib/utils/index";
+import ExpenseSheetSearchRoute, {
+  ExpenseSheetSearchRouteSchema,
+} from "./@expense/route";
+import { ExpenseSheet } from "./@expense/sheet";
+import {
+  SearchRouteStep1 as SettleExpensesSearchRoute,
+  SearchRouteSchema as SettleExpensesSearchRouteSchema,
+} from "./@settle/route";
+import { SettleExpensesDialog } from "./@settle/dialog";
 
 export type ExpenseWithParticipants = ZeroExpense & {
   participants: ParticipantWithMember[];
@@ -160,8 +159,8 @@ export const Route = createFileRoute("/_protected/groups/$slug_id/")({
     ],
   },
   validateSearch: v.object({
-    ...ExpenseSheetSearchRouteSchema.entries,
-    ...SettleExpensesSearchRouteSchema.entries,
+    ...ExpenseSheetSearchRouteSchema.entries, // good
+    ...SettleExpensesSearchRouteSchema.entries, // good
     ...QuerySchema.entries,
     ...StatusSchema.entries,
     ...FiltersSchema.entries,

--- a/packages/web/src/pages/_protected/layout.tsx
+++ b/packages/web/src/pages/_protected/layout.tsx
@@ -24,16 +24,16 @@ import { GlobalCommandBar, SearchRoute } from "./@command-bar.dialog";
 import { ZeroProvider } from "@/lib/zero/zero-provider";
 import { AuthProvider } from "@/lib/authentication/auth-provider";
 import { PropsWithChildren } from "react";
-import { CreateExpenseDialog } from "./@create-expense.dialog";
-import { CreateGroupDialog } from "./groups/@create-group.dialog";
 import { Toaster } from "@/components/ui/sonner";
 import { SearchRouteSchema as GlobalSearchParams } from "./@command-bar.dialog";
-import { SearchRouteSchema as CreateExpenseSearchParams } from "./@create-expense.dialog";
-import { SearchRouteSchema as CreateGroupSearchParams } from "./groups/@create-group.dialog";
+import { CreateExpenseSearchRouteSchema } from "./@create-expense/route";
+import { CreateGroupSearchRouteSchema } from "./@create-group/route";
 import * as v from "valibot";
 import { authenticationQueryOptions } from "@/lib/authentication";
 import { Button } from "@/components/ui/button";
 import { Loading } from "@/components/loading";
+import { CreateExpenseDialog } from "./@create-expense/dialog";
+import { CreateGroupDialog } from "./@create-group/dialog";
 
 function getCookie(name: string, fallback: string) {
   const all = document.cookie.split(";").map((c) => c.trim().split("="));
@@ -199,16 +199,19 @@ export const Route = createFileRoute("/_protected")({
   pendingComponent: () => (
     <Loading whatIsLoading="workspace" className="h-screen m-auto" />
   ),
+  // TODO: need to figure out how to tie down 'template' to 'new-group', otherwise there's no way to conveniently manage this
+  // another option is to update search routes to allow 'sibling keys' which they will handle cleanup for, but do not open
+  // or perhaps the opening could be a parameter as well
   validateSearch: v.object({
-    // here we define search params for ui that can be shown globally
     action: v.optional(
       v.array(
         v.union([
           GlobalSearchParams.entries.action,
-          CreateGroupSearchParams.entries.action,
-          CreateExpenseSearchParams.entries.action,
+          CreateExpenseSearchRouteSchema.entries.action,
+          CreateGroupSearchRouteSchema.entries.action,
         ]),
       ),
     ),
+    template: v.optional(CreateGroupSearchRouteSchema.entries.template),
   }),
 });

--- a/packages/web/src/pages/_protected/page.tsx
+++ b/packages/web/src/pages/_protected/page.tsx
@@ -17,7 +17,6 @@ import {
 } from "@/components/ui/tooltip";
 import { Info } from "lucide-react";
 import { PropsWithChildren } from "react";
-import { buttonVariants } from "@/components/ui/button";
 import { templates } from "./@create-group/templates";
 import GroupSearchRoute from "./@create-group/route";
 


### PR DESCRIPTION
this solves a bug where no default group meant an error hit at the home page 

this solves this
- adds empty sate
- creates a group template concept
- it creates 'sibling' search param to search route concept
- reorganized problematic routes that exported non components/hooks for vite
- fix no default group on initial creation for user