### PR TITLE
feat: expand about page

### DIFF
--- a/packages/web/src/pages/_static/about.page.tsx
+++ b/packages/web/src/pages/_static/about.page.tsx
@@ -6,5 +6,20 @@ export const Route = createFileRoute("/_static/about/")({
 });
 
 function AboutRoute() {
-  return <div>Hello "/_static/about"!</div>;
+  return (
+    <main className="container mx-auto flex min-h-screen flex-col items-center justify-center gap-8 px-6 text-center">
+      <img src="/blank-logo.svg" alt="blank logo" className="h-16 w-16" />
+      <h1 className="text-4xl font-semibold tracking-tight">
+        <span className="uppercase">about</span> blank
+      </h1>
+      <p className="max-w-prose text-lg text-muted-foreground lowercase">
+        blank helps you handle your expenses without the hassle—as easy as
+        sending a text.
+      </p>
+      <p className="max-w-prose text-lg text-muted-foreground lowercase">
+        our mission is to streamline your financial tasks so you can spend more
+        time on what matters.
+      </p>
+    </main>
+  );
 }


### PR DESCRIPTION
## Summary
- center about page content with blank logo and uppercase heading
- render mission statements in lowercase with theme colors

## Testing
- `pnpm test` *(fails: ERR_PNPM_FETCH_403: GET https://registry.npmjs.org/sst: Forbidden - 403)*
- `pnpm --filter @blank/web exec eslint src/pages/_static/about.page.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68afb886aad4832cba450bb20029396d