### PR TITLE
fix: lift empty default preference logic to api handler and set fallback

### DIFF
--- a/packages/core/src/modules/preference/entity.ts
+++ b/packages/core/src/modules/preference/entity.ts
@@ -9,7 +9,7 @@ import {
   requireValueExists,
   TaggedError,
 } from "../../lib/effect";
-import { Preference, PreferenceInsert, preferenceTable } from "./schema";
+import { PreferenceInsert, preferenceTable } from "./schema";
 import { eq } from "drizzle-orm/sql";
 import { db } from "../../lib/drizzle";
 
@@ -38,12 +38,6 @@ export namespace preferences {
       Effect.catchTag(
         "UnknownException",
         (e) => new DatabaseReadError("Failed fetching preference by userId", e),
-      ),
-      Effect.catchTag("PreferenceNotFoundError", () =>
-        Effect.succeed({
-          userId,
-          defaultGroupId: null,
-        } satisfies Preference),
       ),
     );
   }


### PR DESCRIPTION
simplifies logic to handle empty default preference in core function, and lets callers handle the error channel for when such a value doesn't exist

server function provides a fallback as this isn't a strictly required value from a ui perspective