### PR TITLE
feat: preserve intended route on auth redirect via returnTo param

### DIFF
--- a/packages/web/src/lib/authentication/auth-provider.tsx
+++ b/packages/web/src/lib/authentication/auth-provider.tsx
@@ -3,16 +3,23 @@ import { Navigate } from "@tanstack/react-router";
 import { LoadingDelayed } from "@/components/loading";
 import { useQuery } from "@tanstack/react-query";
 import { authenticationQueryOptions } from ".";
+import { usePreserveReturnTo } from "./return-to";
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const query = useQuery(authenticationQueryOptions());
+  const returnTo = usePreserveReturnTo();
 
   if (
     query.status === "error" ||
     (query.status === "pending" && query.failureCount > 0) ||
     (query.status === "success" && !query.data)
   ) {
-    return <Navigate to="/landing" search={(p) => ({ ...p })} />;
+    return (
+      <Navigate
+        to="/landing"
+        search={(prev) => ({ ...prev, returnTo: prev.returnTo ?? returnTo })}
+      />
+    );
   }
 
   if (query.status === "pending") {

--- a/packages/web/src/lib/authentication/return-to.ts
+++ b/packages/web/src/lib/authentication/return-to.ts
@@ -1,0 +1,24 @@
+import { useRouter } from "@tanstack/react-router";
+
+export const RETURN_TO_KEY = "return_to";
+export const ROOT = "/";
+
+export function usePreserveReturnTo() {
+  const { pathname, searchStr, hash } = useRouter().state.location;
+  const fullpath = [pathname, searchStr, hash].join("");
+
+  // no need to set the search param if it's just the root, it clutters the url
+  if (fullpath === "/") return undefined;
+
+  return fullpath;
+}
+
+export function sanitizeReturnTo(path?: string): string | undefined {
+  if (!path) return undefined;
+  // Disallow protocol-relative and absolute URLs
+  if (path.startsWith("//")) return undefined;
+  if (path.includes("://")) return undefined;
+  // Require leading slash
+  if (!path.startsWith("/")) return undefined;
+  return path;
+}

--- a/packages/web/src/pages/_static/landing.page.tsx
+++ b/packages/web/src/pages/_static/landing.page.tsx
@@ -11,11 +11,16 @@ import * as v from "valibot";
 
 function LandingRoute() {
   const login = useServerFn(loginRPC);
+  const search = Route.useSearch();
   const [targetPosition, setTargetPosition] = useState({ x: 0, y: 0 });
   const [laggedPosition, setLaggedPosition] = useState({ x: 0, y: 0 });
   const animationRef = useRef<number>(0);
   const windowSizeRef = useRef({ width: 0, height: 0 });
   const data = Route.useLoaderData();
+
+  function handleLogin() {
+    login({ data: { returnTo: search.returnTo } });
+  }
 
   useClientEffect(() => {
     if (toast.getToasts().length > 0) return;
@@ -187,20 +192,13 @@ function LandingRoute() {
 
       <header className="relative z-10 px-8">
         <nav className="flex items-center justify-between py-4 mx-auto w-full max-w-screen-2xl">
-          <Link
-            search={(prev) => ({
-              action: prev.action,
-              ...prev,
-            })}
-            to="/"
-            className="flex items-center gap-2 duration-150"
-          >
+          <Link to="/" className="flex items-center gap-2 duration-150">
             <img src="/blank-logo.svg" className="w-8 h-8" alt="BLANK logo" />
             <span className="text-xl font-semibold tracking-tight">BLANK</span>
           </Link>
           <div className="md:flex items-center gap-8">
             <Button
-              onClick={() => void login()}
+              onClick={handleLogin}
               variant="outline"
               size="sm"
               className="tracking-wide"
@@ -221,10 +219,7 @@ function LandingRoute() {
             handle your expenses without the hassle— as easy as sending a text.
           </p>
           <div className="flex gap-4 w-full text-center md:w-auto my-4">
-            <Button
-              onClick={() => void login()}
-              className="min-w-44 w-full md:w-auto"
-            >
+            <Button onClick={handleLogin} className="min-w-44 w-full md:w-auto">
               Get Started
             </Button>
             <Button
@@ -251,14 +246,15 @@ function LandingRoute() {
   );
 }
 
-const AuthError = v.object({
+const LandingSearch = v.object({
   auth_error: v.optional(v.pipe(v.string(), v.minLength(1))),
+  returnTo: v.optional(v.string()),
 });
 
 export const Route = createFileRoute("/_static/landing/")({
   ssr: true,
   component: LandingRoute,
-  validateSearch: AuthError,
+  validateSearch: LandingSearch,
   loaderDeps: ({ search: { auth_error } }) => ({ auth_error }),
   loader: (ctx) => {
     const { auth_error } = ctx.deps;

--- a/packages/web/src/server/auth/route.ts
+++ b/packages/web/src/server/auth/route.ts
@@ -1,39 +1,58 @@
 import { subjects } from "@blank/auth/subjects";
 import { redirect } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
+import * as v from "valibot";
 import { authenticate, openauth } from "@/server/auth/core";
 import { AuthTokens, getBaseUrl } from "@/server/utils";
 import { evaluate } from "@/lib/utils";
 import { optional } from "@blank/core/lib/utils/index";
+import {
+  sanitizeReturnTo,
+  ROOT,
+  RETURN_TO_KEY,
+} from "@/lib/authentication/return-to";
+
+const inputs = { login: v.object({ returnTo: v.optional(v.string()) }) };
 
 export const authenticateRPC = createServerFn().handler(async function () {
   return authenticate({ cookies: AuthTokens.cookies });
 });
 
-export const loginRPC = createServerFn().handler(async function () {
-  const { access, refresh } = AuthTokens.cookies.get();
+export const loginRPC = createServerFn()
+  .validator(inputs.login)
+  .handler(async function ({ data }) {
+    const { access, refresh } = AuthTokens.cookies.get();
 
-  if (access) {
-    const verified = await openauth.verify(subjects, access, {
-      ...optional({ refresh }),
+    const returnTo = sanitizeReturnTo(data?.returnTo) ?? ROOT;
+
+    if (access) {
+      const verified = await openauth.verify(subjects, access, {
+        ...optional({ refresh }),
+      });
+
+      if (!verified.err && verified.tokens) {
+        AuthTokens.cookies.set(verified.tokens);
+        throw redirect({ to: returnTo });
+      }
+    }
+
+    const uri = evaluate(() => {
+      const search =
+        returnTo !== ROOT
+          ? `?${RETURN_TO_KEY}=${encodeURIComponent(returnTo)}`
+          : "";
+
+      const path = [getBaseUrl(), "api", "auth", "callback"].join("/");
+
+      return `${path}${search}`;
     });
 
-    if (!verified.err && verified.tokens) {
-      AuthTokens.cookies.set(verified.tokens);
-      throw redirect({ to: "/" });
-    }
-  }
+    if (!uri) throw new Error("Failed to get callback URL");
 
-  const uri = evaluate(() => {
-    return `${getBaseUrl()}/api/auth/callback`; // TODO: fix
+    const { url } = await openauth.authorize(uri, "code");
+
+    throw redirect({ href: url });
   });
-
-  if (!uri) throw new Error("Failed to get callback URL"); // should be a result eventually
-
-  const { url } = await openauth.authorize(uri, "code");
-
-  throw redirect({ href: url });
-});
 
 export const logoutRPC = createServerFn().handler(function () {
   AuthTokens.cookies.delete();


### PR DESCRIPTION
uses `return_to` search param both in ui landing page, as well as in auth flow, to allow the app to return user to their intended location when not auth'd

this is particularly useful for first time users that click on an invitation link, they'll be returned to the group join page after signing up