### PR TITLE
fix: harden mutation authorization

### DIFF
--- a/packages/core/src/modules/invite/entity.ts
+++ b/packages/core/src/modules/invite/entity.ts
@@ -78,6 +78,7 @@ export namespace invites {
 
   export function updateStatus(
     token: string,
+    groupId: string,
     status: "pending" | "accepted" | "expired",
     tx?: Transaction,
   ) {
@@ -89,7 +90,9 @@ export namespace invites {
             status,
             acceptedAt: status === "accepted" ? new Date() : null,
           })
-          .where(eq(inviteTable.token, token))
+          .where(
+            and(eq(inviteTable.token, token), eq(inviteTable.groupId, groupId)),
+          )
           .returning(),
       ),
       Effect.flatMap(

--- a/packages/web/src/lib/client-mutators/expense-mutators.ts
+++ b/packages/web/src/lib/client-mutators/expense-mutators.ts
@@ -1,6 +1,7 @@
 import { Expense } from "@blank/zero";
 import {
   assertIsAuthenticated,
+  assertUserIsGroupMember,
   ClientMutator,
   ClientMutatorGroup,
   ZTransaction,
@@ -53,17 +54,23 @@ type Mutators = ClientMutatorGroup<{
 
 export const mutators: Mutators = (auth) => ({
   update: async (tx, opts) => {
-    assertIsAuthenticated(auth);
+    const authed = assertIsAuthenticated(auth);
 
     const expense = await assertExpenseExists(tx, opts.expenseId);
+    await assertUserIsGroupMember(tx, expense.groupId, authed.userID);
 
     if (opts.updates.expense.status) {
       assertExpenseHasValidSplit(expense as ExpenseWithParticipants);
     }
 
+    const { amount, date, description, status } = opts.updates.expense;
+
     await tx.mutate.expense.update({
       id: opts.expenseId,
-      ...opts.updates.expense,
+      ...(amount !== undefined ? { amount } : {}),
+      ...(date !== undefined ? { date } : {}),
+      ...(description !== undefined ? { description } : {}),
+      ...(status !== undefined ? { status } : {}),
     });
 
     if (!opts.updates.participants) return;
@@ -78,9 +85,10 @@ export const mutators: Mutators = (auth) => ({
     return;
   },
   delete: async (tx, opts) => {
-    assertIsAuthenticated(auth);
+    const authed = assertIsAuthenticated(auth);
 
-    await assertExpenseExists(tx, opts.expenseId);
+    const expense = await assertExpenseExists(tx, opts.expenseId);
+    await assertUserIsGroupMember(tx, expense.groupId, authed.userID);
 
     await tx.mutate.expense.delete({ id: opts.expenseId });
 
@@ -96,7 +104,8 @@ export const mutators: Mutators = (auth) => ({
     }
   },
   deleteByGroupId: async (tx, opts) => {
-    assertIsAuthenticated(auth);
+    const authed = assertIsAuthenticated(auth);
+    await assertUserIsGroupMember(tx, opts.groupId, authed.userID);
 
     const expenses = await tx.query.expense
       .where("groupId", opts.groupId)
@@ -107,7 +116,8 @@ export const mutators: Mutators = (auth) => ({
     }
   },
   bulkSettle: async (tx, opts) => {
-    assertIsAuthenticated(auth);
+    const authed = assertIsAuthenticated(auth);
+    await assertUserIsGroupMember(tx, opts.groupId, authed.userID);
 
     const expenses = await tx.query.expense
       .where("groupId", opts.groupId)

--- a/packages/web/src/lib/client-mutators/group-mutators.ts
+++ b/packages/web/src/lib/client-mutators/group-mutators.ts
@@ -1,4 +1,5 @@
 import { GroupInsert } from "@blank/core/modules/group/schema";
+import { Group } from "@blank/zero";
 import {
   assertIsAuthenticated,
   ClientMutator,
@@ -41,6 +42,12 @@ const assertGroupExists = async (tx: ZTransaction, groupId: string) => {
   return group;
 };
 
+const assertUserOwnsGroup = (group: Group, userId: string) => {
+  if (group.ownerId !== userId) {
+    throw new Error("Only the group owner can perform this action");
+  }
+};
+
 type CreateOptions = Prettify<
   Pick<GroupInsert, "description" | "title"> & {
     id: string;
@@ -61,8 +68,6 @@ type Mutators = ClientMutatorGroup<{
 
 export const mutators: Mutators = (auth) => ({
   create: async (tx, opts) => {
-    const { nickname, ...rest } = opts;
-
     const authed = assertIsAuthenticated(auth);
 
     const groupsUserBelongsTo = await tx.query.group
@@ -73,40 +78,45 @@ export const mutators: Mutators = (auth) => ({
     await assertUserCanJoinGroup(groupsUserBelongsTo.length);
 
     await tx.mutate.group.insert({
+      id: opts.id,
       ownerId: authed.userID,
       createdAt: Date.now(),
       slug: slugify(opts.title).encode(),
-      ...rest,
+      title: opts.title,
+      description: opts.description,
     });
 
     await tx.mutate.member.insert({
       groupId: opts.id,
       userId: authed.userID,
-      nickname,
+      nickname: opts.nickname,
     });
 
     if (groupsUserBelongsTo.length === 0) {
       await tx.mutate.preference.upsert({
         userId: authed.userID,
-        defaultGroupId: rest.id,
+        defaultGroupId: opts.id,
       });
     }
   },
   update: async (tx, opts) => {
-    assertIsAuthenticated(auth);
+    const authed = assertIsAuthenticated(auth);
 
-    await assertGroupExists(tx, opts.groupId);
+    const group = await assertGroupExists(tx, opts.groupId);
+    assertUserOwnsGroup(group, authed.userID);
 
     await tx.mutate.group.update({
       id: opts.groupId,
       slug: slugify(opts.updates.title).encode(),
-      ...opts.updates,
+      title: opts.updates.title,
+      description: opts.updates.description,
     });
   },
   delete: async (tx, opts) => {
     const authed = assertIsAuthenticated(auth);
 
-    await assertGroupExists(tx, opts.groupId);
+    const group = await assertGroupExists(tx, opts.groupId);
+    assertUserOwnsGroup(group, authed.userID);
 
     await tx.mutate.group.delete({ id: opts.groupId });
 

--- a/packages/web/src/lib/client-mutators/index.ts
+++ b/packages/web/src/lib/client-mutators/index.ts
@@ -24,6 +24,20 @@ export function assertIsAuthenticated(auth: OpenAuthToken | undefined) {
   return auth;
 }
 
+export async function assertUserIsGroupMember(
+  tx: ZTransaction,
+  groupId: string,
+  userId: string,
+) {
+  const member = await tx.query.member
+    .where("groupId", groupId)
+    .where("userId", userId)
+    .one()
+    .run();
+
+  if (!member) throw new Error("Must be a group member to perform this action");
+}
+
 export function createClientMutators(auth: OpenAuthToken | undefined) {
   return {
     expense: expenseMutators(auth),

--- a/packages/web/src/lib/client-mutators/participant-mutators.ts
+++ b/packages/web/src/lib/client-mutators/participant-mutators.ts
@@ -1,6 +1,11 @@
-import { Participant } from "@blank/zero";
+import { Expense, Participant } from "@blank/zero";
 import { Prettify } from "@blank/core/lib/utils/index";
-import { assertIsAuthenticated, ClientMutator, ClientMutatorGroup } from ".";
+import {
+  assertIsAuthenticated,
+  assertUserIsGroupMember,
+  ClientMutator,
+  ClientMutatorGroup,
+} from ".";
 
 export type UpdateParticipant = Prettify<
   Required<Pick<Participant, "userId" | "expenseId">> &
@@ -20,16 +25,32 @@ type Mutators = ClientMutatorGroup<{
   updateMany: ClientMutator<UpdateManyOptions, void>;
 }>;
 
+function assertExpenseExists(
+  expense: Expense | undefined,
+): asserts expense is Expense {
+  if (!expense) throw new Error("Expense not found");
+}
+
 export const mutators: Mutators = (auth) => ({
   update: async (tx, opts) => {
-    assertIsAuthenticated(auth);
+    const authed = assertIsAuthenticated(auth);
 
-    const { expenseId, userId, ...rest } = opts.participant;
+    const expense = await tx.query.expense
+      .where("id", opts.participant.expenseId)
+      .one()
+      .run();
+
+    assertExpenseExists(expense);
+
+    await assertUserIsGroupMember(tx, expense.groupId, authed.userID);
+
+    const { expenseId, userId, role, split } = opts.participant;
 
     await tx.mutate.participant.update({
       expenseId,
       userId,
-      ...rest,
+      ...(role !== undefined ? { role } : {}),
+      ...(split !== undefined ? { split } : {}),
     });
   },
   updateMany: async (tx, opts) => {

--- a/packages/web/src/server/auth/route.ts
+++ b/packages/web/src/server/auth/route.ts
@@ -53,7 +53,9 @@ export const loginRPC = createServerFn()
     throw redirect({ href: url });
   });
 
-export const logoutRPC = createServerFn().handler(function () {
-  AuthTokens.cookies.delete();
-  throw redirect({ to: "/landing", reloadDocument: true });
-});
+export const logoutRPC = createServerFn({ method: "POST" }).handler(
+  function () {
+    AuthTokens.cookies.delete();
+    throw redirect({ to: "/landing", reloadDocument: true });
+  },
+);

--- a/packages/web/src/server/expense.route.ts
+++ b/packages/web/src/server/expense.route.ts
@@ -1,5 +1,5 @@
 import { createServerFn } from "@tanstack/react-start";
-import { expenses, users } from "@blank/core/modules";
+import { expenses, members, users } from "@blank/core/modules";
 import {
   requireUserAuthenticated,
   UserAuthorizationError,
@@ -39,6 +39,7 @@ export const createFromDescriptionServerFn = createServerFn({
       const auth = yield* requireUserAuthenticated(AuthTokens.cookies);
 
       const user = yield* users.getById(auth.subject.properties.userID);
+      yield* members.get(user.id, ctx.data.groupId);
 
       if (ctx.data.images.length > 0) {
         yield* assertHasImageContextPerms(user);

--- a/packages/web/src/server/invite.route.ts
+++ b/packages/web/src/server/invite.route.ts
@@ -140,7 +140,7 @@ export const getInvitesByGroupServerFn = createServerFn()
     return pipe(handler(), Effect.runPromise);
   });
 
-export const createGroupInviteServerFn = createServerFn()
+export const createGroupInviteServerFn = createServerFn({ method: "POST" })
   .validator(inputs.createInviteToken)
   .handler(async function ({ data }) {
     const handler = Effect.fn("createGroupInvite")(function* () {
@@ -165,7 +165,7 @@ export const createGroupInviteServerFn = createServerFn()
     return pipe(handler(), Effect.runPromise);
   });
 
-export const revokeInviteServerFn = createServerFn()
+export const revokeInviteServerFn = createServerFn({ method: "POST" })
   .validator(inputs.revokeInvite)
   .handler(async function ({ data }) {
     const handler = Effect.fn("revokeInvite")(function* () {
@@ -177,7 +177,12 @@ export const revokeInviteServerFn = createServerFn()
         Effect.fn("revokeInviteTx")(function* (tx) {
           yield* assertUserIsOwner(data.groupId, userId, "revoke invite", tx);
 
-          return yield* invites.updateStatus(data.token, "expired", tx);
+          return yield* invites.updateStatus(
+            data.token,
+            data.groupId,
+            "expired",
+            tx,
+          );
         }),
       );
 
@@ -187,7 +192,7 @@ export const revokeInviteServerFn = createServerFn()
     return pipe(handler(), Effect.runPromise);
   });
 
-export const joinGroupServerFn = createServerFn()
+export const joinGroupServerFn = createServerFn({ method: "POST" })
   .validator(inputs.joinGroup)
   .handler(async function ({ data }) {
     const handler = Effect.fn("joinGroup")(function* () {
@@ -223,7 +228,12 @@ export const joinGroupServerFn = createServerFn()
             yield* preferences.upsert(userId, data.groupId, tx);
           }
 
-          yield* invites.updateStatus(token.token, "accepted", tx);
+          yield* invites.updateStatus(
+            token.token,
+            token.groupId,
+            "accepted",
+            tx,
+          );
 
           return member;
         }),

--- a/packages/web/src/server/preferences.route.ts
+++ b/packages/web/src/server/preferences.route.ts
@@ -4,6 +4,7 @@ import * as v from "valibot";
 import { requireUserAuthenticated } from "./auth/core";
 import { AuthTokens } from "./utils";
 import { preferences } from "@blank/core/modules/preference/entity";
+import { members } from "@blank/core/modules/member/entity";
 
 const inputs = {
   updateDefaultGroup: v.object({
@@ -35,13 +36,14 @@ export const getUserPreferencesServerFn = createServerFn().handler(
   },
 );
 
-export const updateDefaultGroupServerFn = createServerFn()
+export const updateDefaultGroupServerFn = createServerFn({ method: "POST" })
   .validator(inputs.updateDefaultGroup)
   .handler(async function ({ data }) {
     const handler = Effect.fn("updateDefaultGroup")(function* () {
       const auth = yield* requireUserAuthenticated(AuthTokens.cookies);
 
       const userId = auth.subject.properties.userID;
+      yield* members.get(userId, data.defaultGroupId);
 
       const updatedPreferences = yield* preferences.upsert(
         userId,

--- a/packages/web/src/server/user.route.ts
+++ b/packages/web/src/server/user.route.ts
@@ -93,7 +93,7 @@ export const meRPC2 = createServerFn().handler(async function () {
   return Effect.runPromise(result);
 });
 
-export const updateUserServerFn = createServerFn()
+export const updateUserServerFn = createServerFn({ method: "POST" })
   .validator(inputs.updateUser)
   .handler(async function ({ data }) {
     const handler = Effect.fn("updateUser")(function* () {


### PR DESCRIPTION
## Summary
- require group ownership for group updates and deletion
- require group membership for expense, participant, AI expense, and preference mutations
- allowlist mutable fields and bind invite status updates to their group
- send state-changing server functions with POST

## Verification
- `pnpm typecheck`
- `pnpm --filter @blank/web build`
- Prettier and `git diff --check`

## Notes
- Existing tests were not run because Bun is unavailable in the environment.
- Repository-wide lint remains blocked by pre-existing unrelated errors.